### PR TITLE
fix: specify numbers for speaker query

### DIFF
--- a/components/hooks/useCommunitySupport.tsx
+++ b/components/hooks/useCommunitySupport.tsx
@@ -10,7 +10,7 @@ type PartnerType = {
 };
 
 const query = gql`query partners {
-  partners (where: {show:true, isCommunitySupport:true}) {
+  partners (first: 20, where: {show:true, isCommunitySupport:true}) {
     url
     name
     img

--- a/components/hooks/useMediaPartners.tsx
+++ b/components/hooks/useMediaPartners.tsx
@@ -10,7 +10,7 @@ type MediaPartnerProps = {
 };
 
 const query = gql`query partners {
-  mediaPartner (where: {show:true}) {
+  mediaPartner (first: 100, where: {show:true}) {
     url
     name
     img

--- a/components/hooks/useOrganizers.tsx
+++ b/components/hooks/useOrganizers.tsx
@@ -11,7 +11,7 @@ type OrganizerType = {
 };
 
 const query = gql`query organizers {
-  organizers {
+  organizers (first: 20) {
     name
     titleAndCompany
     profile

--- a/components/hooks/usePartners.tsx
+++ b/components/hooks/usePartners.tsx
@@ -10,7 +10,7 @@ type PartnerType = {
 };
 
 const query = gql`query partners {
-  partners (where: {show:true, isCommunitySupport:false}) {
+  partners (first: 100, where: {show:true, isCommunitySupport:false}) {
     url
     name
     img

--- a/components/hooks/useSpeakers.tsx
+++ b/components/hooks/useSpeakers.tsx
@@ -13,7 +13,7 @@ export type SpeakerProps = {
 };
 
 const query = gql`query Speakers {
-  speakers (where: { show: true }) {
+  speakers (first: 100, where: { show: true }) {
     name
     company
     companyLink

--- a/components/hooks/useSponsors.tsx
+++ b/components/hooks/useSponsors.tsx
@@ -12,7 +12,7 @@ export type SpeakerProps = {
 };
 
 const query = gql`query sponsors {
-  sponsors (where: {show:true}) {
+  sponsors (first: 100, where: {show:true}) {
     url
     name
     img


### PR DESCRIPTION
可以在 hygrpah 的 API playground 驗證

```GraphQL
query Speakers {
  speakers(first: 100, where: {show: true}) {
    name
    company
    companyLink
    img
    profile
    createdAt
    id
    publishedAt
    show
    updatedAt
    keynote
  }
}
```