### PR TITLE
Update banner

### DIFF
--- a/components/HomePage/Banner.tsx
+++ b/components/HomePage/Banner.tsx
@@ -11,7 +11,7 @@ import {
   sponsorApplyUrl,
   tickSiteUrl,
 } from "@/public/constant/urls";
-import bgImage from "@/public/images/eth-taipei-banner-background-2.png";
+import bgImage from "@/public/images/eth-taipei-banner-2024-2.jpg";
 import banner from "@/public/images/vertical-transparent.png";
 import { openNewTab } from "@/public/utils/common";
 import gtagReportConversion from "@/public/utils/gtag";
@@ -53,10 +53,10 @@ const Banner = () => {
 
   return (
     <Container>
-      <Image src={bgImage} fill quality={100} alt="bgImage" />
+      <Image src={bgImage} fill quality={100} style={{ opacity: 0.18 }} alt="bgImage" />
       <ImageContainer>
         <Image src={banner} alt="logo" fill />
-        <YearWatermark>2024</YearWatermark>
+        {/* <YearWatermark>2024</YearWatermark> */}
       </ImageContainer>
       <ActivitiesContainer>
         <ActivityBtn onClick={handleOpenUnlock}>
@@ -70,16 +70,16 @@ const Banner = () => {
       </ActivitiesContainer>
       <ApplicationsContainer>
         <ActivityBtn onClick={handleApplySpeaker}>
-          <ActivityTitle>{t.homepage.applyToSpeak}</ActivityTitle>
+          <ActivityTitle2>{t.homepage.applyToSpeak}</ActivityTitle2>
         </ActivityBtn>
         <ActivityBtn onClick={handleApplySponsor}>
-          <ActivityTitle>{t.homepage.applyToSponsor}</ActivityTitle>
-        </ActivityBtn>
-        <ActivityBtn onClick={handleBecomeMediaPartner}>
-          <ActivityTitle>{t.homepage.applyToMediaPartner}</ActivityTitle>
+          <ActivityTitle2>{t.homepage.applyToSponsor}</ActivityTitle2>
         </ActivityBtn>
         <ActivityBtn onClick={handleApplySideEvent}>
-          <ActivityTitle>{t.homepage.applyToSideEvent}</ActivityTitle>
+          <ActivityTitle2>{t.homepage.applyToSideEvent}</ActivityTitle2>
+        </ActivityBtn>
+        <ActivityBtn onClick={handleBecomeMediaPartner}>
+          <ActivityTitle2>{t.homepage.applyToMediaPartner}</ActivityTitle2>
         </ActivityBtn>
       </ApplicationsContainer>
     </Container>
@@ -154,7 +154,7 @@ const ApplicationsContainer = styled.div`
 const ActivityBtn = styled.button`
   flex: 1;
   padding: 20px;
-  border-radius: 8px;
+  border-radius: 15px;
   background-color: ${Colors.seaSalt};
   display: flex;
   flex-direction: column;
@@ -169,7 +169,7 @@ const ActivityBtn = styled.button`
 `;
 
 const ActivityTitle = styled.h2`
-  font-size: 20px;
+  font-size: 25px;
   line-height: 28px;
   font-weight: bold;
   color: ${Colors.pennBlue};
@@ -179,6 +179,13 @@ const ActivityTitle = styled.h2`
 const ActivityDate = styled.h3`
   font-size: 20px;
   line-height: 24px;
+  color: ${Colors.pennBlue};
+  display: block;
+`;
+
+const ActivityTitle2 = styled.h2`
+  font-size: 20px;
+  line-height: 28px;
   color: ${Colors.pennBlue};
   display: block;
 `;

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -38,13 +38,13 @@ const navItems = [
     isNewTab: true,
     isPlugin: false,
   },
-  {
-    label: t.navs.home,
-    value: "/",
-    disabled: false,
-    isNewTab: false,
-    isPlugin: false,
-  },
+  // {
+  //   label: t.navs.home,
+  //   value: "/",
+  //   disabled: false,
+  //   isNewTab: false,
+  //   isPlugin: false,
+  // },
   {
     label: t.navs.agenda,
     value: "/agenda",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,7 +16,6 @@ const Home = () => {
   return (
     <div>
       <Banner />
-      <PromoteCallToAction />
       <Recap />
       <CountdownTimer />
       <Introduction />
@@ -28,6 +27,7 @@ const Home = () => {
       <Partners />
       <Organizers />
       <CommunitySupport />
+      <PromoteCallToAction />
     </div>
   );
 };


### PR DESCRIPTION
主要是更新 banner 圖片和調整一些 style。採用去年的活動照片，人很多的那種，讓人第一眼就可以看到這個活動很熱鬧，也和去年有區別性。我知道 Danny 有設計新的 UI，但我認為有必要先做調整

## New
![截圖 2024-02-21 下午9 29 10](https://github.com/ETHTaipei/ETH-Taipei-Website/assets/8311552/2237b672-c2ae-47eb-88a2-b0f9776110d9)

## Old
![截圖 2024-02-21 下午9 29 05](https://github.com/ETHTaipei/ETH-Taipei-Website/assets/8311552/fdcf1ac1-a139-4a25-ac16-f0ade5f25fa9)

另外做了兩個調整
1. header 移除 home，因為點 logo 就有同樣效果
2. reorder promoteCalltoAction，因為 banner、header 都有 CTA buttons，所以我放到最後面讓使用者看完網站後再看到一次 CTA buttons