### PR TITLE
fix: bypass next/image optimization (Netlify IPX broken)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    // Netlify's next/image proxy (`/_ipx/...`) is broken — its sharp module can't
+    // load libvips, so every optimized request returns 500. Bypass the optimizer
+    // and serve the raw source files (which load fine). Source assets are already
+    // sized reasonably; re-enable only if we move off Netlify.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
The hero logo and other `<Image>` components are broken on https://ethtaipei.org/. Root cause is Netlify's `_ipx` image proxy returning **HTTP 500** on every request:

```
IPX Error: Error:
Something went wrong installing the "sharp" module

libvips-cpp.so.42: cannot open shared object file: No such file or directory
```

This is a Netlify runtime regression — the `sharp` module on their function can't load `libvips`. Affects **every** `next/image` URL (`/_next/image?url=...` → `/_ipx/...`), not just the hero logo. Raw static files at `/images/...` still return 200, so the simplest fix is to bypass Next's image optimizer entirely.

## Change
- `next.config.js`: add `images.unoptimized: true` so `<Image>` components render against the raw source file paths.

## Trade-offs
- Lose on-the-fly resizing / format conversion. Source assets in `public/images/` are already reasonably sized (the hero logo is 37KB).
- Re-enable once Netlify fixes their IPX function, or if the site moves to Vercel.

## Test plan
- [x] `npm run build` exits 0
- [x] Local dev: `<Image>` `currentSrc` is now `/images/FirstViewBanner/ETHTaipeiOrg.webp` (not `/_next/image?...`) and loads
- [ ] Post-deploy: hero logo + recap photos + venue images render on https://ethtaipei.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)