### PR TITLE
Render Banner on home page only

### DIFF
--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import Header from "./Header";
-import Banner from "@/components/HomePage/Banner";
 
 const Layout: React.FC<{ children: React.ReactNode }> = (props) => {
   const { children } = props;
@@ -8,7 +7,6 @@ const Layout: React.FC<{ children: React.ReactNode }> = (props) => {
   return (
     <>
       <Header />
-      <Banner />
       <Main>{children}</Main>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import Banner from "@/components/HomePage/Banner";
 import Events from "@/components/HomePage/Events";
 import Introduction from "@/components/HomePage/Introduction";
 import Recap from "@/components/HomePage/Recap";
@@ -43,6 +44,7 @@ const DynamicCommunitySupport = dynamic(
 const Home = ({ initialApolloState }: any) => {
   return (
     <ApolloWrapper pageProps={{ initialApolloState }}>
+      <Banner />
       <Recap />
       <Introduction />
       <Events />


### PR DESCRIPTION
## Summary
- `<Banner />` (full home hero — logo, 2026 year tag, date/venue, countdown, video) lives in `components/Layout/index.tsx`, which wraps every page. That means `/agenda` and `/visainfo` also render the home hero above their own content.
- Move the import + render into `pages/index.tsx` so only `/` shows the hero. Layout now renders only `<Header />` + `<Main>{children}</Main>`.

## Test plan
- [ ] `npm run build` (passes locally)
- [ ] `/` still renders hero above Recap, no visual regression
- [ ] `/agenda` renders Header + agenda only (no hero)
- [ ] `/visainfo` renders Header + visa content only (no hero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)