### PR TITLE
Hotfix: restore BrandBgVideo on all pages

### DIFF
--- a/components/HomePage/Banner.tsx
+++ b/components/HomePage/Banner.tsx
@@ -7,7 +7,7 @@ import { sideEventFormUrl, speakerApplyUrl } from "@/public/constant/urls";
 import Colors from "@/styles/colors";
 import { diagonalSymmetricBorder } from "@/styles/constants";
 import CountdownTimer from "./CountdownTimer";
-import { Video, BrandBgVideo } from "./Video";
+import { Video } from "./Video";
 
 const monthAbbr = month.slice(0, 3).toUpperCase();
 const dayRange = "13–15"; // 13–15 with en dash
@@ -129,7 +129,6 @@ const Banner = () => {
         <PixelIconMountain />
       </RightSection>
       <GridOverlay />
-      <BrandBgVideo />
     </Container>
   );
 };

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,11 +1,13 @@
 import styled from "styled-components";
 import Header from "./Header";
+import { BrandBgVideo } from "@/components/HomePage/Video";
 
 const Layout: React.FC<{ children: React.ReactNode }> = (props) => {
   const { children } = props;
 
   return (
     <>
+      <BrandBgVideo />
       <Header />
       <Main>{children}</Main>
     </>


### PR DESCRIPTION
## Summary
Fixes a regression introduced by #316. The site-wide background video (`BrandBgVideo`, `position: fixed`, `z-index: -2`, full-viewport) used to be rendered inside `<Banner />`. Moving `<Banner />` out of the shared Layout removed the background from every non-home route — `/agenda` and `/visainfo` now show plain white.

This PR moves `<BrandBgVideo />` into `components/Layout/index.tsx` so it covers every page, and drops the import + render from `components/HomePage/Banner.tsx` so it doesn't render twice on the home page.

## Test plan
- [ ] Home `/` still has the icon-transform background (no visible change)
- [ ] `/agenda` shows the background instead of plain white
- [ ] `/visainfo` shows the background instead of plain white
- [ ] Network tab loads `icon_transform.webm` exactly once per page

🤖 Generated with [Claude Code](https://claude.com/claude-code)