### PR TITLE
Skip Apollo queries when FLAGS off; gate GA + Hygraph on env vars

### DIFF
--- a/components/hooks/usePartners.tsx
+++ b/components/hooks/usePartners.tsx
@@ -1,5 +1,6 @@
 import { year } from "@/public/constant/content";
 import { gql, useQuery } from "@apollo/client";
+import { FLAGS } from "@/public/constant/flags";
 import { COMMUNITY_PARTNER, PARTNER } from "@/public/constant/logo_width";
 
 export type PartnerType = {
@@ -46,7 +47,10 @@ export const COMMUNITY_QUERY = gql`
 `;
 
 export const usePartners = () => {
-  const { data } = useQuery<{ partners: PartnerType[] }>(PARTNER_QUERY);
+  // Year-templated collection (partners2026) 400s until seeded; skip when off.
+  const { data } = useQuery<{ partners: PartnerType[] }>(PARTNER_QUERY, {
+    skip: !FLAGS.showPartners,
+  });
 
   const partners =
     data?.partners.map((partner) => ({
@@ -59,7 +63,8 @@ export const usePartners = () => {
 
 export const useMediaPartners = () => {
   const { data } = useQuery<{ partners: MediaPartnerType[] }>(
-    MEDIAPARTNER_QUERY
+    MEDIAPARTNER_QUERY,
+    { skip: !FLAGS.showMediaPartners },
   );
 
   const mediaPartners =

--- a/components/hooks/useSponsors.tsx
+++ b/components/hooks/useSponsors.tsx
@@ -1,5 +1,6 @@
 import { year } from "@/public/constant/content";
 import { gql, useQuery } from "@apollo/client";
+import { FLAGS } from "@/public/constant/flags";
 import { PLATINUM, GOLD, SILVER, BRONZE } from "@/public/constant/logo_width";
 
 export type SponsorProps = {
@@ -21,7 +22,12 @@ export const SPONSOR_QUERY = gql`query {
 `;
 
 export const useSponsors = () => {
-  const { data } = useQuery<{ sponsors: SponsorProps[] }>(SPONSOR_QUERY);
+  // The query references the year-templated collection (e.g. sponsors2026)
+  // which Hygraph 400s on until the schema is seeded. Skip until the section
+  // is launched to avoid console errors and wasted requests.
+  const { data } = useQuery<{ sponsors: SponsorProps[] }>(SPONSOR_QUERY, {
+    skip: !FLAGS.showSponsors,
+  });
 
   const all = data?.sponsors || [];
 

--- a/components/providers/apollo.tsx
+++ b/components/providers/apollo.tsx
@@ -11,10 +11,18 @@ import { useMemo } from "react";
 
 let apolloClient: ApolloClient<NormalizedCacheObject> | undefined;
 
+// Fallback preserves the existing Hygraph endpoint so deploys without the
+// env var keep working. Set NEXT_PUBLIC_HYGRAPH_ENDPOINT in Vercel to swap
+// CMS environments (e.g. point staging at a different Hygraph project)
+// without a redeploy.
+const HYGRAPH_ENDPOINT =
+  process.env.NEXT_PUBLIC_HYGRAPH_ENDPOINT ||
+  "https://us-east-1-shared-usea1-02.cdn.hygraph.com/content/clrhiw5ac1aas01w2yynlhlw9/master";
+
 function createApolloClient() {
   return new ApolloClient({
     ssrMode: typeof window === "undefined", // True on server, false on client
-    uri: "https://us-east-1-shared-usea1-02.cdn.hygraph.com/content/clrhiw5ac1aas01w2yynlhlw9/master",
+    uri: HYGRAPH_ENDPOINT,
     cache: new InMemoryCache(),
   });
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -41,27 +41,32 @@ export default class MyDocument extends Document {
   }
 
   render() {
+    const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS;
     return (
       <Html>
         <Head>
           {/* <link rel="stylesheet" href="/fonts/fonts.css" /> */}
           {/* Global Site Tag (gtag.js) - Google Analytics */}
-          <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}
-          />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
+          {gaId && (
+            <>
+              <script
+                async
+                src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+              />
+              <script
+                dangerouslySetInnerHTML={{
+                  __html: `
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
-            gtag('config', '${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}', {
+            gtag('config', '${gaId}', {
               page_path: window.location.pathname,
             });
           `,
-            }}
-          />
+                }}
+              />
+            </>
+          )}
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" />
           <link


### PR DESCRIPTION
## Summary
Three small hardening changes for the home page:

1. **Apollo `skip` on FLAGS** — `useSponsors`, `usePartners`, `useMediaPartners` now pass `{ skip: !FLAGS.show* }` to `useQuery`. These reference year-templated Hygraph collections (`sponsors2026`, `partners2026`, …) which return 400 until the schema is seeded — pre-launch, every home-page load was firing failed requests and spamming the console.
2. **Hygraph endpoint env var** — `components/providers/apollo.tsx` reads `NEXT_PUBLIC_HYGRAPH_ENDPOINT` when set, falls back to the existing hardcoded URL so deploys without the env var keep working.
3. **GA conditional render** — gtag script in `_document.tsx` now only renders when `NEXT_PUBLIC_GOOGLE_ANALYTICS` is defined. Previously the prod HTML included `<script src="…?id=undefined">` and `gtag('config', 'undefined', …)` whenever the env was missing.

## Not in this PR
- `next.config.js` `images.unoptimized: true` is correctly working around Netlify's broken IPX proxy (confirmed via the Netlify deploy preview bot on #316). Removing it would break image loading. The CRM/website README that says "Vercel" is wrong; will be fixed in a separate doc PR.

## Test plan
- [ ] `npm run build` (passes locally)
- [ ] Home `/` no longer fires `sponsors2026` / `partners2026` requests while those FLAGS are false (DevTools → Network → filter by `hygraph`)
- [ ] With `NEXT_PUBLIC_HYGRAPH_ENDPOINT` set, requests go to the new endpoint
- [ ] With `NEXT_PUBLIC_GOOGLE_ANALYTICS` unset, no GA script tags in `<head>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)