### PR TITLE
chore: small cleanups + annotate archived hackathon components

### DIFF
--- a/components/AgendaPage/HackathonTable.tsx
+++ b/components/AgendaPage/HackathonTable.tsx
@@ -1,3 +1,7 @@
+// ARCHIVED — not currently rendered. Two-track hackathon agenda table.
+// ETHTaipei skipped its hackathon track for 2026; the 2026 soft-launch
+// refactor (PR #314, May 2026) dropped this import from Agendas.tsx. Kept
+// as a template — revive when hackathon programming returns.
 import styled from "styled-components";
 
 import { hackathonAgendas } from "@/public/constant/agendas";

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -81,7 +81,7 @@ const applyDropdownItems = [
 
 const PagesNav = () => {
   const [showApplyDropdown, setShowApplyDropdown] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const { handleOnClickExternalLink, handleOnClickInternalLink } = useRouting();
 
   // 200ms delay before hiding s.t. applyDropdown won't disappear so fast

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "next": "^13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-gtm-module": "^2.0.11",
     "react-icons": "^4.8.0",
     "react-transition-group": "^4.4.5",
     "styled-components": "^5.3.6",
@@ -39,7 +38,6 @@
   },
   "devDependencies": {
     "@types/google-map-react": "^2.1.7",
-    "@types/react-gtm-module": "^2.0.1",
     "@types/styled-components": "^5.1.26",
     "babel-plugin-styled-components": "^2.0.7",
     "vitest": "^2.1.9"


### PR DESCRIPTION
## Summary
Three light-touch cleanups from the website Medium-issue backlog. Net: −3 / +5 lines across 3 files.

### 1. Drop unused \`react-gtm-module\` + \`@types/react-gtm-module\`
The site uses hand-rolled \`gtag\` in \`pages/_document.tsx\`. \`react-gtm-module\` was added but never imported.

### 2. Fix \`useRef<NodeJS.Timeout>()\` type
\`components/Layout/Header.tsx:84\` was passing no initial value to \`useRef\`, which React 18's stricter types reject. Change to \`useRef<NodeJS.Timeout | null>(null)\`. Runtime behavior unchanged.

### 3. Annotate \`HackathonTable\` only
ETHTaipei doesn't have a hackathon track for 2026 (confirmed with the team). \`HackathonTable.tsx\` now starts with an \`ARCHIVED — not currently rendered.\` comment explaining its history and how to revive it if hackathon programming returns.

## What's intentionally left as-is
- \`VitalikTable\`, \`SideEventTable\`, \`SideEventItem\`, \`EventSwitcher\`, \`HackathonItem\` — also currently unmounted, but they're expected to be re-rendered later this cycle once content lands. No comment needed.
- Closing-party copy block in \`content.ts\` (\`eventName_5\`, \`eventDate_5\` etc.) — kept; will be revived once the 2026 closing party has confirmed details.

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run test\` (5 tests pass)
- [x] \`npm run build\` succeeds locally
- [ ] Netlify deploy preview renders home, agenda, visainfo correctly (no visual regression expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)