### PR TITLE
build: migrate styled-components from Babel plugin to Next SWC compiler

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["next/babel"],
-  "plugins": [["styled-components", { "ssr": true }]]
-}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Use Next's SWC compiler for styled-components (faster builds, smaller
+  // output, native SSR class continuity). Previously enabled via .babelrc +
+  // babel-plugin-styled-components, which forced the entire app through
+  // Babel and disabled SWC for everything else.
+  compiler: {
+    styledComponents: true,
+  },
   images: {
     // Netlify's next/image proxy (`/_ipx/...`) is broken — its sharp module can't
     // load libvips, so every optimized request returns 500. Bypass the optimizer

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/google-map-react": "^2.1.7",
     "@types/react-gtm-module": "^2.0.1",
     "@types/styled-components": "^5.1.26",
-    "babel-plugin-styled-components": "^2.0.7",
     "vitest": "^2.1.9"
   }
 }


### PR DESCRIPTION
## Summary
Replace the \`.babelrc\` + \`babel-plugin-styled-components\` setup with Next's built-in SWC compiler support for styled-components.

**Why:** while \`.babelrc\` exists, Next 13 disables SWC site-wide and routes every file through Babel. Removing it lets the entire app compile via SWC — the recommended path since Next 12.

The \`.babelrc\` has been present since the project's first feature commit (Annie Chi, Feb 2023) and never modified. Just legacy default from when SWC support for styled-components was still maturing.

## Changes
- Delete \`.babelrc\`
- \`next.config.js\`: add \`compiler.styledComponents: true\`
- \`package.json\`: drop the now-unused \`babel-plugin-styled-components\` devDep

## Behavior parity
- The SWC compiler enables \`displayName\` and \`ssr\` (stable class identifiers across SSR/CSR) **by default**, matching the previous Babel plugin's \`{ ssr: true }\` option.
- \`pages/_document.tsx\`'s manual \`ServerStyleSheet\` style collection is still needed and untouched.

## Expected wins
- Faster builds (no Babel pass over the whole app)
- Slightly smaller client bundle
- Build output no longer prints \`Disabled SWC as replacement for Babel because of custom Babel configuration ".babelrc"\`

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run test\` (5 tests pass)
- [x] \`npm run build\` succeeds locally; no "Disabled SWC" warning
- [ ] Netlify deploy preview renders home, agenda, visainfo correctly — this is the real check. A class-name mismatch between SSR and CSR would produce a hydration warning in DevTools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)