### PR TITLE
feat: add Community page showcasing the Taipei Ethereum ecosystem

### DIFF
--- a/components/CommunityPage/index.tsx
+++ b/components/CommunityPage/index.tsx
@@ -1,0 +1,427 @@
+import Image from "next/image";
+import styled from "styled-components";
+
+import t from "@/public/constant/content";
+import {
+  coscupUrl,
+  ethereumFoundationUrl,
+  geodeLabsUrl,
+  localEthereumTaiwanUrl,
+  lumaEmbedUrl,
+  lumaUrl,
+  newsletterUrl,
+  temMediumUrl,
+  xueDaoUrl,
+} from "@/public/constant/urls";
+import { useRouting } from "@/public/utils/common";
+import type { FeedPost } from "@/public/utils/rss";
+import Colors from "@/styles/colors";
+import { diagonalSymmetricBorder } from "@/styles/constants";
+
+type Props = {
+  mediumPosts: FeedPost[];
+  newsletterPosts: FeedPost[];
+};
+
+const PostList = ({
+  posts,
+  heading,
+  onOpen,
+}: {
+  posts: FeedPost[];
+  heading: string;
+  onOpen: (url: string) => void;
+}) => {
+  if (!posts.length) return null;
+  return (
+    <PostListContainer>
+      <PostListHeading>{heading}</PostListHeading>
+      {posts.map((post) => (
+        <PostItem key={post.link} onClick={() => onOpen(post.link)}>
+          <PostTitle>{post.title}</PostTitle>
+          {post.pubDate && <PostDate>{post.pubDate}</PostDate>}
+        </PostItem>
+      ))}
+    </PostListContainer>
+  );
+};
+
+const CommunityPage = ({ mediumPosts, newsletterPosts }: Props) => {
+  const { handleOnClickExternalLink } = useRouting();
+
+  return (
+    <Container id="info">
+      <MainContent>
+        <Title>
+          <ImageWrapper>
+            <Image
+              src="/images/icons/butterfly.svg"
+              alt="community"
+              width={48}
+              height={48}
+              style={{ marginRight: 4 }}
+            />
+          </ImageWrapper>
+          {t.community.title}
+        </Title>
+        <Subtitle>{t.community.subtitle}</Subtitle>
+        <Description>{t.community.intro1}</Description>
+        <Description>{t.community.intro2}</Description>
+
+        {/* Monthly meetups */}
+        <SectionTitle>{t.community.meetupsTitle}</SectionTitle>
+        <Description>{t.community.meetupsIntro}</Description>
+        <MeetupGrid>
+          <MeetupCard>
+            <MeetupName>{t.community.tldrName}</MeetupName>
+            <MeetupDate>
+              <Icon>
+                <Image
+                  src="/images/FirstViewBanner/Date_Icon.svg"
+                  alt="Date"
+                  fill
+                  style={{ objectFit: "cover" }}
+                />
+              </Icon>
+              {t.community.tldrDate}
+            </MeetupDate>
+            <MeetupDesc>{t.community.tldrDesc}</MeetupDesc>
+          </MeetupCard>
+          <MeetupCard>
+            <MeetupName>{t.community.featuredName}</MeetupName>
+            <MeetupDate>
+              <Icon>
+                <Image
+                  src="/images/FirstViewBanner/Date_Icon.svg"
+                  alt="Date"
+                  fill
+                  style={{ objectFit: "cover" }}
+                />
+              </Icon>
+              {t.community.featuredDate}
+            </MeetupDate>
+            <MeetupDesc>{t.community.featuredDesc}</MeetupDesc>
+          </MeetupCard>
+        </MeetupGrid>
+        <Description>
+          {t.community.meetupsOutro1}
+          <Link onClick={() => handleOnClickExternalLink(lumaUrl)}>
+            {t.community.meetupsSubscribe}
+          </Link>
+          {t.community.meetupsOutro2}
+        </Description>
+        <CalendarEmbed
+          title="Upcoming Community Events"
+          src={lumaEmbedUrl}
+          width="100%"
+          height="auto"
+          allowFullScreen
+          aria-hidden="false"
+          tabIndex={0}
+          loading="lazy"
+        />
+
+        {/* COSCUP track */}
+        <SectionTitle>{t.community.coscupTitle}</SectionTitle>
+        <Description>
+          {t.community.coscupDesc1}
+          <Link onClick={() => handleOnClickExternalLink(coscupUrl)}>
+            {t.community.coscupLink}
+          </Link>
+          {t.community.coscupDesc2}
+        </Description>
+
+        {/* Taipei Ethereum Meetup Medium column */}
+        <SectionTitle>{t.community.mediumTitle}</SectionTitle>
+        <Description>
+          {t.community.mediumDesc1}
+          <Link onClick={() => handleOnClickExternalLink(temMediumUrl)}>
+            {t.community.mediumLink}
+          </Link>
+          {t.community.mediumDesc2}
+        </Description>
+        <PostList
+          posts={mediumPosts}
+          heading={t.community.mediumLatest}
+          onOpen={handleOnClickExternalLink}
+        />
+
+        {/* Newsletter */}
+        <SectionTitle>{t.community.newsletterTitle}</SectionTitle>
+        <Description>
+          {t.community.newsletterDesc1}
+          <Link onClick={() => handleOnClickExternalLink(newsletterUrl)}>
+            {t.community.newsletterName}
+          </Link>
+          {t.community.newsletterDesc2}
+        </Description>
+        <PostList
+          posts={newsletterPosts}
+          heading={t.community.newsletterLatest}
+          onOpen={handleOnClickExternalLink}
+        />
+        <Description>
+          <Link onClick={() => handleOnClickExternalLink(newsletterUrl)}>
+            {t.community.newsletterSubscribe}
+          </Link>
+        </Description>
+
+        {/* Local Ethereum coverage */}
+        <SectionTitle>{t.community.coverageTitle}</SectionTitle>
+        <Description>{t.community.coverageDesc}</Description>
+        <FeatureCard
+          onClick={() => handleOnClickExternalLink(localEthereumTaiwanUrl)}
+        >
+          <FeatureCardSource>{t.community.coverageCardSource}</FeatureCardSource>
+          <FeatureCardTitle>{t.community.coverageCardTitle}</FeatureCardTitle>
+          <FeatureCardBody>{t.community.coverageCardBody}</FeatureCardBody>
+          <FeatureCardCta>{t.community.coverageCardCta}</FeatureCardCta>
+        </FeatureCard>
+
+        {/* XueDAO */}
+        <SectionTitle>{t.community.xuedaoTitle}</SectionTitle>
+        <Description>
+          {t.community.xuedaoDesc1}
+          <Link onClick={() => handleOnClickExternalLink(xueDaoUrl)}>
+            {t.community.xuedaoLink}
+          </Link>
+          {t.community.xuedaoDesc2}
+        </Description>
+
+        {/* Sponsor thanks */}
+        <SectionTitle>{t.community.thanksTitle}</SectionTitle>
+        <Description>
+          {t.community.thanksDesc1}
+          <Link
+            onClick={() => handleOnClickExternalLink(ethereumFoundationUrl)}
+          >
+            {t.community.thanksEF}
+          </Link>
+          {t.community.thanksDesc2}
+          <Link onClick={() => handleOnClickExternalLink(geodeLabsUrl)}>
+            {t.community.thanksGeode}
+          </Link>
+          {t.community.thanksDesc3}
+        </Description>
+      </MainContent>
+    </Container>
+  );
+};
+
+export default CommunityPage;
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  background-color: rgba(33, 35, 37, 1);
+  min-height: 100vh;
+`;
+
+const MainContent = styled.div`
+  width: 100%;
+  max-width: 860px;
+  padding: 120px 40px;
+
+  @media (max-width: 768px) {
+    padding: 60px 24px;
+  }
+`;
+
+const ImageWrapper = styled.div`
+  display: flex;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
+
+const Title = styled.h1`
+  color: ${Colors.neonGreen};
+  text-align: center;
+  font-size: 48px;
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+
+  @media (max-width: 768px) {
+    font-size: 36px;
+  }
+`;
+
+const Subtitle = styled.div`
+  font-size: 22px;
+  color: white;
+  display: flex;
+  text-align: center;
+  justify-content: center;
+  margin-top: 16px;
+  margin-bottom: 24px;
+`;
+
+const SectionTitle = styled.h2`
+  font-size: 28px;
+  font-weight: bold;
+  color: ${Colors.neonGreen};
+  margin-top: 48px;
+  margin-bottom: 12px;
+
+  @media (max-width: 768px) {
+    font-size: 24px;
+  }
+`;
+
+const Description = styled.div`
+  color: white;
+  font-family: Inter;
+  font-size: 16px;
+  line-height: 26px;
+  margin-top: 12px;
+`;
+
+const Link = styled.a`
+  color: ${Colors.aero};
+  cursor: pointer;
+  text-decoration: underline;
+  :hover {
+    color: ${Colors.neonGreen};
+  }
+`;
+
+const MeetupGrid = styled.div`
+  margin-top: 24px;
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
+`;
+
+const MeetupCard = styled.div`
+  flex: 1;
+  padding: 24px;
+  border: 3px solid ${Colors.brightBlue};
+  ${diagonalSymmetricBorder}
+`;
+
+const MeetupName = styled.h3`
+  font-size: 24px;
+  color: white;
+  text-shadow: -2px 0 ${Colors.brightBlue}, 0 2px ${Colors.brightBlue},
+    2px 0 ${Colors.brightBlue}, 0 -2px ${Colors.brightBlue};
+`;
+
+const MeetupDate = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: ${Colors.neonGreen};
+  font-size: 16px;
+  margin-top: 12px;
+`;
+
+const Icon = styled.div`
+  position: relative;
+  width: 24px;
+  height: 24px;
+`;
+
+const MeetupDesc = styled.div`
+  color: white;
+  font-family: Inter;
+  font-size: 14px;
+  line-height: 24px;
+  margin-top: 12px;
+`;
+
+const CalendarEmbed = styled.iframe`
+  margin-top: 24px;
+  border: none;
+  min-height: 370px;
+`;
+
+const PostListContainer = styled.div`
+  margin-top: 16px;
+  border-left: 3px solid ${Colors.brightBlue};
+  padding-left: 16px;
+`;
+
+const PostListHeading = styled.div`
+  color: ${Colors.gray3};
+  font-family: Inter;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+`;
+
+const PostItem = styled.div`
+  margin-top: 12px;
+  cursor: pointer;
+
+  :hover > div:first-child {
+    color: ${Colors.neonGreen};
+  }
+`;
+
+const PostTitle = styled.div`
+  color: ${Colors.aero};
+  font-family: Inter;
+  font-size: 16px;
+  line-height: 24px;
+  text-decoration: underline;
+  transition: color 200ms ease;
+`;
+
+const PostDate = styled.div`
+  color: ${Colors.gray3};
+  font-family: Inter;
+  font-size: 13px;
+  margin-top: 2px;
+`;
+
+const FeatureCard = styled.div`
+  margin-top: 24px;
+  padding: 24px;
+  border: 3px solid ${Colors.brightBlue};
+  ${diagonalSymmetricBorder}
+  cursor: pointer;
+  transition: transform 200ms ease;
+
+  :hover {
+    transform: scale(1.01);
+  }
+`;
+
+const FeatureCardSource = styled.div`
+  color: ${Colors.gray3};
+  font-family: Inter;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+`;
+
+const FeatureCardTitle = styled.h3`
+  color: white;
+  font-size: 24px;
+  margin-top: 8px;
+  text-shadow: -2px 0 ${Colors.brightBlue}, 0 2px ${Colors.brightBlue},
+    2px 0 ${Colors.brightBlue}, 0 -2px ${Colors.brightBlue};
+`;
+
+const FeatureCardBody = styled.div`
+  color: white;
+  font-family: Inter;
+  font-size: 14px;
+  line-height: 24px;
+  margin-top: 12px;
+`;
+
+const FeatureCardCta = styled.div`
+  color: ${Colors.neonGreen};
+  font-family: Inter;
+  font-size: 15px;
+  margin-top: 16px;
+`;

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -69,6 +69,7 @@ const navItems = [
     disabled: !FLAGS.showApplyCTAs && !speakerApplyUrl,
   },
   { label: t.navs.venue, path: "/#venue", disabled: false },
+  { label: t.navs.community, path: "/community#info", disabled: false },
   { label: t.navs.visaInfo, path: "/visainfo#info", disabled: false },
 ];
 

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -1,0 +1,38 @@
+import type { GetStaticProps } from "next";
+
+import CommunityPage from "@/components/CommunityPage";
+import Layout from "@/components/Layout";
+import {
+  newsletterFeedUrl,
+  temMediumFeedUrl,
+} from "@/public/constant/urls";
+import { fetchLatestPosts, FeedPost } from "@/public/utils/rss";
+
+type CommunityProps = {
+  mediumPosts: FeedPost[];
+  newsletterPosts: FeedPost[];
+};
+
+export const getStaticProps: GetStaticProps<CommunityProps> = async () => {
+  // Fetched at build time and re-fetched hourly via ISR (same cadence as the
+  // home page); a feed outage degrades to an empty list, never a build break.
+  const [mediumPosts, newsletterPosts] = await Promise.all([
+    fetchLatestPosts(temMediumFeedUrl),
+    fetchLatestPosts(newsletterFeedUrl),
+  ]);
+
+  return {
+    props: { mediumPosts, newsletterPosts },
+    revalidate: 3600, // revalidate every hour
+  };
+};
+
+const Community = ({ mediumPosts, newsletterPosts }: CommunityProps) => {
+  return (
+    <CommunityPage mediumPosts={mediumPosts} newsletterPosts={newsletterPosts} />
+  );
+};
+
+Community.getLayout = (page: React.ReactNode) => <Layout>{page}</Layout>;
+
+export default Community;

--- a/public/constant/content.ts
+++ b/public/constant/content.ts
@@ -78,7 +78,7 @@ const homepage = {
   eventBtn_3: "See Events",
   eventName_4: "Community Events",
   eventDesc_4:
-    "At ETHTaipei, we host regular monthly events: Meetups on the first Wed and talks on the third Wed of every month. Wanna hang out with us and the local communities? Click on the event links to sign up and subscribe for more!",
+    "Ethereum in Taipei never stops: we host the TLDR Meetup (1st Wed) and Featured Talk Meetup (3rd Wed) every month, curate the blockchain track at COSCUP, publish technical articles and a newsletter with Taipei Ethereum Meetup, and cheer on student builders at XueDAO. Explore it all on our Community page — and subscribe so you never miss an event!",
   eventDate_4: "every 1st & 3rd Wed",
   eventBtn_4: "Subscribe",
 
@@ -110,6 +110,63 @@ const navs = {
   venue: "Venue",
   brand: "Brand",
   event: "Events",
+  community: "Community",
+};
+
+const community = {
+  title: "Community",
+  subtitle: "Ethereum in Taipei is alive all year round",
+  intro1: `ETHTaipei is the annual flagship gathering, but it is only one chapter of a much bigger story. Taiwan's Ethereum scene is one of the most active in Asia — grassroots, volunteer-driven, and deeply technical. Developers, researchers, students, and enthusiasts meet every month, publish technical writing, curate conference tracks, and onboard the next generation of builders.`,
+  intro2: `This page gathers the communities, events, and publications that keep the ecosystem buzzing between conferences. Come say hi — everyone is welcome.`,
+
+  meetupsTitle: "Monthly Meetups",
+  meetupsIntro: `We host two regular meetups in Taipei every month, free and open to everyone:`,
+  tldrName: "TLDR Meetup",
+  tldrDate: "1st Wednesday of every month",
+  tldrDesc: `Short, digestible sessions where community members break down what they have been reading and building — protocol changes, DeFi mechanisms, security incidents, and fresh research, summarized so you don't have to read everything yourself.`,
+  featuredName: "Featured Talk Meetup",
+  featuredDate: "3rd Wednesday of every month",
+  featuredDesc: `A deeper technical session with invited speakers from the local and international Ethereum community — the same spirit as the talks on the ETHTaipei stage, all year round.`,
+  meetupsOutro1: `Want to join us? `,
+  meetupsSubscribe: "Subscribe on Luma",
+  meetupsOutro2: ` to get notified about every upcoming meetup, and browse the calendar for what we've hosted before.`,
+
+  coscupTitle: "COSCUP — Blockchain & Distributed Ledger Track",
+  coscupDesc1: `Every summer, the community also curates the Blockchain and Distributed Ledger track at `,
+  coscupLink: "COSCUP",
+  coscupDesc2: `, Asia's largest open-source community conference, held annually in Taipei. COSCUP is free to attend and entirely community-organized — a natural home for Ethereum in Taiwan, where the open-source movement and the blockchain community have always grown side by side.`,
+
+  mediumTitle: "Taipei Ethereum Meetup — Medium Column",
+  mediumDesc1: `Running since 2016, Taipei Ethereum Meetup is one of Taiwan's earliest and most enduring Ethereum communities, and its `,
+  mediumLink: "Medium column",
+  mediumDesc2: ` has grown into a library of technical writing in Chinese and English: protocol deep dives, EIP explainers, meetup recaps, and research summaries contributed by the community.`,
+  mediumLatest: "Latest articles",
+
+  newsletterTitle: "Newsletter",
+  newsletterDesc1: `Can't make it in person? The `,
+  newsletterName: "ETHTaipei x TEM newsletter",
+  newsletterDesc2: ` collects the materials shared at each meetup, plus additional technical articles and ecosystem news — a monthly snapshot of what the Taipei community is reading, building, and debating.`,
+  newsletterLatest: "Latest issues",
+  newsletterSubscribe: "Subscribe to the newsletter",
+
+  coverageTitle: "Featured by Local Ethereum",
+  coverageDesc: `Taiwan's ecosystem has also caught international attention — Local Ethereum, the publication mapping Ethereum communities around the world, profiled our scene in depth:`,
+  coverageCardSource: "Local Ethereum · March 2026",
+  coverageCardTitle: "Taiwan Ethereum Ecosystem Overview",
+  coverageCardBody: `A deep dive into Taiwan's grassroots communities, builders, developer talent, and digital-democracy culture — and why its Ethereum scene stands out for its community ownership and volunteer spirit rather than corporate dominance.`,
+  coverageCardCta: "Read the full article →",
+
+  xuedaoTitle: "XueDAO",
+  xuedaoDesc1: `The community here is bigger than any single organization. `,
+  xuedaoLink: "XueDAO",
+  xuedaoDesc2: ` is Taiwan's first student-led developer community, on a mission to show the world that Taiwanese students can BUIDL. With contributors from 12+ universities, XueDAO runs study groups, networking events, and the student-only XueDAO CONNECT hackathon — the on-ramp for the next generation of Taiwanese builders.`,
+
+  thanksTitle: "Thank You",
+  thanksDesc1: `These year-round community programs are made possible by the generous support of the `,
+  thanksEF: "Ethereum Foundation",
+  thanksDesc2: ` and `,
+  thanksGeode: "Geode Labs",
+  thanksDesc3: ` — a spin-out of the Ethereum Foundation dedicated to growing local Ethereum ecosystems around the world, and the team behind Local Ethereum. Thank you for helping the Taipei community thrive.`,
 };
 
 const callToAction = {
@@ -141,6 +198,7 @@ const t = {
   navs,
   callToAction,
   visa,
+  community,
 };
 
 export default t;

--- a/public/constant/urls.ts
+++ b/public/constant/urls.ts
@@ -1,7 +1,7 @@
 export const xUrl = "https://twitter.com/EthTaipei";
 export const discordUrl = "https://discord.gg/Dqa2nfEsgv";
 export const telegramUrl = "https://t.me/ethtaipei";
-export const lumaUrl = "https://lu.ma/ETHTaipei_2026";
+export const lumaUrl = "https://luma.com/ETHTaipei_2025";
 export const lumaEmbedUrl =
   "https://lu.ma/embed/calendar/cal-ZhI6svRCCQYhkqn/events?lt=dark";
 export const closingPartyUrl = "";
@@ -117,3 +117,15 @@ export const goldcardVickyHoMailUrl = "mailto:vicky_ho@mail.tca.org.tw";
 export const goldcardKellyChuangMailUrl = "mailto:kelly_chuang@mail.tca.org.tw";
 
 export const invitationLetterUrl = "https://forms.gle/Ms8KGf8K621vyvMG6";
+
+// Community page
+export const temMediumUrl = "https://medium.com/taipei-ethereum-meetup";
+export const coscupUrl = "https://coscup.org/2026/en";
+export const localEthereumTaiwanUrl =
+  "https://localethereum.substack.com/p/taiwan-ethereum-ecosystem-overview";
+export const xueDaoUrl = "https://www.xuedao.xyz/";
+export const geodeLabsUrl = "https://geode.build/";
+export const newsletterUrl = "https://ethtaipeixtem.substack.com/";
+// RSS feeds consumed at build/revalidate time by /community's getStaticProps.
+export const temMediumFeedUrl = "https://medium.com/feed/taipei-ethereum-meetup";
+export const newsletterFeedUrl = "https://ethtaipeixtem.substack.com/feed";

--- a/public/utils/rss.ts
+++ b/public/utils/rss.ts
@@ -1,0 +1,56 @@
+// Minimal RSS <item> extractor for the /community page. Runs server-side only
+// (getStaticProps), so no CORS concerns. Deliberately dependency-free: we only
+// need title / link / pubDate from well-formed feeds (Medium, Substack), and a
+// fetch failure should degrade to an empty list, never break the build.
+
+export type FeedPost = {
+  title: string;
+  link: string;
+  pubDate: string;
+};
+
+const stripCdata = (s: string) =>
+  s.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1").trim();
+
+const tagContent = (block: string, tag: string): string => {
+  const m = block.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
+  return m ? stripCdata(m[1]) : "";
+};
+
+const formatDate = (rfc822: string): string => {
+  const d = new Date(rfc822);
+  if (isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+export async function fetchLatestPosts(
+  feedUrl: string,
+  limit = 3
+): Promise<FeedPost[]> {
+  try {
+    const res = await fetch(feedUrl, {
+      headers: { "user-agent": "ethtaipei.org website build" },
+    });
+    if (!res.ok) return [];
+    const xml = await res.text();
+
+    const posts: FeedPost[] = [];
+    const itemRe = /<item>([\s\S]*?)<\/item>/g;
+    let m: RegExpExecArray | null;
+    while ((m = itemRe.exec(xml)) !== null && posts.length < limit) {
+      const block = m[1];
+      const title = tagContent(block, "title");
+      // Medium appends ?source=rss tracking params; drop them for clean URLs.
+      const link = tagContent(block, "link").split("?")[0];
+      if (!title || !link) continue;
+      posts.push({ title, link, pubDate: formatDate(tagContent(block, "pubDate")) });
+    }
+    return posts;
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## What

New **`/community`** page (nav: between Venue and Visa Info) gathering the year-round community activity around ETHTaipei, plus a rephrased Community Events card on the home page that points to it.

### Sections

- **Monthly Meetups** — TLDR Meetup (1st Wed) & Featured Talk Meetup (3rd Wed) as cards, a *Subscribe on Luma* link, and the same live Luma calendar embed as the home page.
- **COSCUP — Blockchain & Distributed Ledger track** — curated yearly at Asia's largest open-source conference.
- **Taipei Ethereum Meetup Medium column** — intro + the **3 latest articles rendered live from the publication's RSS feed**.
- **Newsletter (ETHTaipei x TEM)** — intro + the **3 latest issues from the Substack RSS feed** + subscribe link.
- **Featured by Local Ethereum** — the *Taiwan Ethereum Ecosystem Overview* as a clickable feature card. (Direct embedding is blocked: Substack serves `frame-ancestors 'self' *.substack.com`, so an iframe can't render on ethtaipei.org.)
- **XueDAO** — Taiwan's first student-led developer community.
- **Thank You** — crediting the **Ethereum Foundation** and **Geode Labs** (EF spin-out, also the team behind Local Ethereum).

### How the live feeds work

`getStaticProps` + **hourly ISR** (same cadence the home page already uses) fetches both RSS feeds with a dependency-free parser (`public/utils/rss.ts`). A feed outage degrades to hiding the list — it can never break a build. No new dependencies, no client-side CORS issues.

### Also in this PR

- `lumaUrl` corrected to the public **luma.com/ETHTaipei_2025** calendar — this also fixes the home page Subscribe button, which pointed at a non-existent `lu.ma/ETHTaipei_2026`.
- Home page `eventDesc_4` rephrased to summarize the whole ecosystem (meetups, COSCUP, Medium, newsletter, XueDAO) and point to the new page.

## Verification

- ESLint clean, vitest 5/5, production build green: `/community` builds as **ISR (3600s)**, feeds fetched in ~830ms at build time.
- Rendering verified by headless-browser screenshot (real feed data: TEM Medium latest articles + newsletter issues #30–#32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)