### PR TITLE
feat: add Buy Ticket and Sponsor Inquiry CTAs to hero banner

### DIFF
--- a/components/HomePage/Banner.tsx
+++ b/components/HomePage/Banner.tsx
@@ -3,7 +3,12 @@ import styled from "styled-components";
 
 import t, { month, year } from "@/public/constant/content";
 import { FLAGS } from "@/public/constant/flags";
-import { sideEventFormUrl, speakerApplyUrl } from "@/public/constant/urls";
+import {
+  sideEventFormUrl,
+  speakerApplyUrl,
+  sponsorApplyUrl,
+  tickSiteUrl,
+} from "@/public/constant/urls";
 import Colors from "@/styles/colors";
 import { diagonalSymmetricBorder } from "@/styles/constants";
 import CountdownTimer from "./CountdownTimer";
@@ -93,8 +98,16 @@ const Banner = () => {
           <CountdownTimer />
         </CountdownContainer>
         <HeroCtaContainer>
+          <HeroCta href={tickSiteUrl} target="_blank" rel="noreferrer">
+            Buy Ticket
+            <CtaArrow>→</CtaArrow>
+          </HeroCta>
           <HeroCta href={speakerApplyUrl} target="_blank" rel="noreferrer">
             Apply to Speak
+            <CtaArrow>→</CtaArrow>
+          </HeroCta>
+          <HeroCta href={sponsorApplyUrl} target="_blank" rel="noreferrer">
+            Sponsor Inquiry
             <CtaArrow>→</CtaArrow>
           </HeroCta>
         </HeroCtaContainer>
@@ -202,6 +215,9 @@ const YearTag = styled.div`
 
 const HeroCtaContainer = styled.div`
   margin-top: 28px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
 `;
 
 const HeroCta = styled.a`

--- a/public/constant/urls.ts
+++ b/public/constant/urls.ts
@@ -6,14 +6,14 @@ export const lumaEmbedUrl =
   "https://lu.ma/embed/calendar/cal-ZhI6svRCCQYhkqn/events?lt=dark";
 export const closingPartyUrl = "";
 
-export const sponsorApplyUrl = "";
+export const sponsorApplyUrl = "https://boost.ethtaipei.org/sponsor-inquiry";
 export const speakerApplyUrl =
   "https://ethtaipei-boost-production.up.railway.app/apply/speaker";
 export const sideEventApplyUrl = "";
 export const mediaPartnerApplyUrl = "";
 export const hackathonUrl = "";
 export const sideEventFormUrl = "";
-export const tickSiteUrl = "";
+export const tickSiteUrl = "https://app.moongate.id/e/eth-taipei-2026";
 
 export const code4renaUrl = "https://code4rena.com/";
 export const diamondUrl = "https://dmo.finance/";


### PR DESCRIPTION
## Summary
- Add **Buy Ticket** and **Sponsor Inquiry** buttons next to the existing **Apply to Speak** button in the hero banner
- Fill in `tickSiteUrl` → https://app.moongate.id/e/eth-taipei-2026 (Moongate ticket page)
- Fill in `sponsorApplyUrl` → https://boost.ethtaipei.org/sponsor-inquiry (Boost sponsor inquiry form)
- Make the hero CTA container a wrapping flex row so the three buttons lay out cleanly on all screen sizes

## Notes
- Filling `sponsorApplyUrl` also enables the previously-disabled "to Sponsor" item in the header's Apply dropdown
- The header/Events "Buy Ticket" entries remain hidden behind `FLAGS.showTickets` (still `false`) — flip it in a follow-up when tickets should be visible site-wide

## Test plan
- `yarn tsc --noEmit` passes
- Verified locally: three pill buttons render under the countdown, wrapping to a second row at narrow widths, all opening the correct URLs in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)