### PR TITLE
chore: update event date to Sep 13–14

### DIFF
--- a/components/HomePage/Banner.tsx
+++ b/components/HomePage/Banner.tsx
@@ -15,7 +15,7 @@ import CountdownTimer from "./CountdownTimer";
 import { Video } from "./Video";
 
 const monthAbbr = month.slice(0, 3).toUpperCase();
-const dayRange = "13–15"; // 13–15 with en dash
+const dayRange = "13–14"; // 13–14 with en dash
 
 const Banner = () => {
   return (
@@ -43,7 +43,7 @@ const Banner = () => {
             </CalendarBlock>
             <InfoWrapper>
               <InfoTitle>{t.homepage.bannerInfoTitle_1}</InfoTitle>
-              <InfoDescription>3-day event</InfoDescription>
+              <InfoDescription>2-day event</InfoDescription>
             </InfoWrapper>
           </Info>
         </InfoContainer>

--- a/components/HomePage/Home2026.tsx
+++ b/components/HomePage/Home2026.tsx
@@ -397,7 +397,7 @@ const Hero2026 = () => {
             <span className={styles.heroYear}>{year}</span>
           </h1>
           <p className={styles.lede}>
-            Three days where Taiwan&apos;s builders meet the global Ethereum stack,
+            Two days where Taiwan&apos;s builders meet the global Ethereum stack,
             from core protocol research to account abstraction and consumer crypto.
           </p>
           <div className={styles.actions} id="apply">

--- a/public/constant/agendas.ts
+++ b/public/constant/agendas.ts
@@ -3,8 +3,8 @@ import { StaticImageData } from "next/image";
 export type EventType = "conference" | "sideEvent";
 
 export const dates = {
-  conference: [13, 14, 15],
-  sideEvent: [13, 14, 15],
+  conference: [13, 14],
+  sideEvent: [13, 14],
 };
 
 export type HackathonItemType = {

--- a/public/constant/content.ts
+++ b/public/constant/content.ts
@@ -1,10 +1,10 @@
 export const year = "2026";
 export const month = "September";
-export const dateDayMonthYear = `SEP 13–15, ${year}`;
+export const dateDayMonthYear = `SEP 13–14, ${year}`;
 
 const common = {
   ethTaipei: `ETHTaipei ${year} | ${dateDayMonthYear}`,
-  ethTaipeiIntro: `Welcome to ETHTaipei ${year} event held in Taiwan. With a thriving Ethereum and developer community in Taiwan, ETHTaipei ${year} brings together teams from around the world to participate in a 3-day conference focusing on the application and technology of Ethereum.`,
+  ethTaipeiIntro: `Welcome to ETHTaipei ${year} event held in Taiwan. With a thriving Ethereum and developer community in Taiwan, ETHTaipei ${year} brings together teams from around the world to participate in a 2-day conference focusing on the application and technology of Ethereum.`,
 };
 
 const homepage = {
@@ -62,7 +62,7 @@ const homepage = {
   eventSubTitle: "From Deep Dives to Fun Vibes – Experience It All!",
   eventName_1: "Conference",
   eventDesc_1:
-    "Three days of talks and discussions with Ethereum researchers, builders, and industry leaders. Tracks and session details will be announced soon.",
+    "Two days of talks and discussions with Ethereum researchers, builders, and industry leaders. Tracks and session details will be announced soon.",
   eventDate_1: dateDayMonthYear,
   eventBtn_1: "Ticket",
   // eventName_2: "Hackathon",


### PR DESCRIPTION
## Summary
Updates the event date from **Sep 13–15** to **Sep 13–14** everywhere it appears, and updates the duration copy that derives from that range (a 13–14 event is 2 days, so "3-day" / "Three days" became "2-day" / "Two days").

## Changes
- **`public/constant/content.ts`** — `dateDayMonthYear` (`SEP 13–14`), and conference intro/description copy (`3-day` → `2-day`, `Three days` → `Two days`).
- **`components/HomePage/Banner.tsx`** — hero `dayRange` (`13–14`) and the `2-day event` label.
- **`components/HomePage/Home2026.tsx`** — hero lede (`Two days ...`).
- **`public/constant/agendas.ts`** — `conference` and `sideEvent` day arrays `[13, 14]`. This automatically drives the per-day agenda switcher (one tab per day) and the "N-day agenda" placeholder text via `dates.conference.length`.

## Notes
- Commented-out hackathon copy still mentions "three-day" but is inactive, so it was left untouched.
- Please confirm the duration-wording changes are desired — they were made for consistency with the new 2-day range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)