### PR TITLE
feat: refresh 2026 UI and visa page

### DIFF
--- a/components/HomePage/Home2026.module.css
+++ b/components/HomePage/Home2026.module.css
@@ -199,36 +199,86 @@
 }
 
 .socialLinks {
-  gap: 9px;
+  position: relative;
+  gap: 3px;
+  padding: 5px;
+  overflow: hidden;
+  border: 1px solid rgb(203 241 1 / 0.34);
+  border-radius: 4px 14px 4px 14px;
+  background:
+    linear-gradient(
+      90deg,
+      rgb(203 241 1 / 0.16),
+      transparent 18% 82%,
+      rgb(57 82 255 / 0.22)
+    ),
+    linear-gradient(180deg, oklch(14% 0.034 255 / 0.82), oklch(8% 0.021 255 / 0.68));
+  box-shadow:
+    inset 0 0 0 1px oklch(0% 0 0 / 0.3),
+    0 0 0 1px oklch(96% 0.018 126 / 0.05),
+    0 16px 34px -24px rgb(203 241 1 / 0.7);
+  backdrop-filter: blur(14px);
+  isolation: isolate;
+}
+
+.socialLinks::before,
+.socialLinks::after {
+  position: absolute;
+  z-index: -1;
+  content: "";
+  pointer-events: none;
+}
+
+.socialLinks::before {
+  inset: 3px;
+  border: 1px solid rgb(203 241 1 / 0.14);
+  border-radius: 2px 10px 2px 10px;
+  background-image:
+    linear-gradient(rgb(203 241 1 / 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(203 241 1 / 0.12) 1px, transparent 1px);
+  background-size: 8px 8px;
+  opacity: 0.72;
+}
+
+.socialLinks::after {
+  inset: -60% auto -60% -38%;
+  width: 34%;
+  background: linear-gradient(90deg, transparent, rgb(203 241 1 / 0.35), transparent);
+  transform: skewX(-18deg) translateX(-130%);
+  transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.socialLinks:hover::after {
+  transform: skewX(-18deg) translateX(520%);
 }
 
 .socialLink {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: 2px solid white;
-  border-radius: 50%;
-  background: #303fc7;
-  opacity: 0.82;
-  box-shadow: 0 0 0 rgb(203 241 1 / 0);
-  transition: border-color 0.18s ease, background-color 0.18s ease,
-    box-shadow 0.18s ease, transform 0.18s ease, opacity 0.18s ease;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid rgb(203 241 1 / 0.1);
+  border-radius: 2px 9px 2px 9px;
+  color: oklch(86% 0.026 254);
+  background: oklch(8% 0.022 255 / 0.58);
+  transition: color 0.2s ease, background 0.2s ease,
+    border-color 0.2s ease, transform 0.2s ease, filter 0.2s ease;
 }
 
 .socialLink img {
-  width: 58%;
-  height: 58%;
+  width: 18px;
+  height: 18px;
   object-fit: contain;
 }
 
 .socialLink:hover {
-  border-color: var(--acid);
-  background: #4a5cff;
-  opacity: 1;
-  box-shadow: 0 0 18px rgb(203 241 1 / 0.42);
-  transform: translateY(-2px) scale(1.06);
+  border-color: rgb(203 241 1 / 0.28);
+  color: var(--acid);
+  background: rgb(203 241 1 / 0.08);
+  filter: drop-shadow(0 0 12px rgb(203 241 1 / 0.34));
+  transform: translateY(-1px);
 }
 
 .socialLink:focus-visible {
@@ -537,8 +587,9 @@
 
 .countdown {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 10px;
+  width: 100%;
 }
 
 .timebox,
@@ -551,6 +602,10 @@
 }
 
 .timebox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   min-width: 0;
   padding: 13px 8px 12px;
   border-radius: 14px;
@@ -559,20 +614,25 @@
 
 .timebox strong {
   display: block;
+  width: 100%;
   color: var(--acid);
   font-size: clamp(34px, 4.6vw, 52px);
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
   letter-spacing: 0.06em;
   line-height: 0.9;
+  text-align: center;
   text-shadow: 0 0 18px rgb(203 241 1 / 0.45);
 }
 
 .timebox span {
   display: block;
+  width: 100%;
   margin-top: 7px;
   color: oklch(70% 0.02 255);
   font-size: 11px;
   letter-spacing: 0.18em;
+  text-align: center;
   text-transform: uppercase;
 }
 
@@ -957,6 +1017,59 @@
   background: #111;
 }
 
+.eventCalendarEmpty {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  width: 100%;
+  min-height: 320px;
+  padding: 32px;
+  overflow: hidden;
+  border: 1px solid rgb(203 241 1 / 0.24);
+  border-radius: 24px 8px 24px 8px;
+  background:
+    linear-gradient(135deg, rgb(203 241 1 / 0.08), transparent 45%, rgb(57 82 255 / 0.1)),
+    #0b1117;
+  box-shadow:
+    inset 0 0 0 1px rgb(255 255 255 / 0.03),
+    0 2px 4px oklch(0% 0 0 / 0.5),
+    0 14px 30px -10px oklch(0% 0 0 / 0.62),
+    0 42px 100px -42px oklch(1% 0.02 260 / 0.9);
+  isolation: isolate;
+}
+
+.eventCalendarEmpty::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  opacity: 0.16;
+  background-image:
+    linear-gradient(rgb(203 241 1 / 0.18) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(203 241 1 / 0.18) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask-image: radial-gradient(circle at center, black, transparent 78%);
+}
+
+.eventCalendarEmptyIcon {
+  width: 48px;
+  height: 48px;
+  color: #cbf101;
+  filter: drop-shadow(0 0 16px rgb(203 241 1 / 0.5));
+}
+
+.eventCalendarEmpty p {
+  max-width: 340px;
+  color: white;
+  font-size: clamp(22px, 2.4vw, 30px);
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: center;
+}
+
 .hero [data-depth] {
   will-change: transform;
   transition: transform 0.12s linear;
@@ -1059,6 +1172,7 @@
 
   .dataStack {
     justify-self: stretch;
+    min-width: 0;
     width: 100%;
     max-width: 620px;
   }
@@ -1155,6 +1269,11 @@
 
   .eventRow {
     flex-direction: column;
+  }
+
+  .eventCalendarEmpty {
+    min-height: 240px;
+    padding: 24px;
   }
 
   .eventMedia {

--- a/components/HomePage/Home2026.tsx
+++ b/components/HomePage/Home2026.tsx
@@ -1,4 +1,5 @@
 import t, { dateDayMonthYear, year } from "@/public/constant/content";
+import { FLAGS } from "@/public/constant/flags";
 import {
   lumaEmbedUrl,
   lumaUrl,
@@ -49,9 +50,9 @@ const tickerItems = [
 ];
 
 const socialLinks = [
+  { label: "Discord", href: discordUrl, icon: "/images/social-icons/discord_icon.svg" },
   { label: "X", href: xUrl, icon: "/images/social-icons/x_icon.svg" },
   { label: "Telegram", href: telegramUrl, icon: "/images/social-icons/telegram_icon.svg" },
-  { label: "Discord", href: discordUrl, icon: "/images/social-icons/discord_icon.svg" },
 ];
 
 const venueMapsUrl = `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(
@@ -570,14 +571,21 @@ const Events2026 = () => (
           buttonText={t.homepage.eventBtn_4}
           href={lumaUrl}
         />
-        <DeferredIframe
-          className={styles.eventCalendar}
-          title="Events Calendar"
-          src={lumaEmbedUrl}
-          allowFullScreen
-          aria-hidden="false"
-          tabIndex={0}
-        />
+        {FLAGS.showCommunityCalendar ? (
+          <DeferredIframe
+            className={styles.eventCalendar}
+            title="Events Calendar"
+            src={lumaEmbedUrl}
+            allowFullScreen
+            aria-hidden="false"
+            tabIndex={0}
+          />
+        ) : (
+          <aside className={styles.eventCalendarEmpty} aria-label="Community events status">
+            <Star className={styles.eventCalendarEmptyIcon} />
+            <p>More community events coming soon</p>
+          </aside>
+        )}
       </div>
     </div>
   </section>

--- a/components/Layout/Header2026.tsx
+++ b/components/Layout/Header2026.tsx
@@ -1,0 +1,176 @@
+import {
+  discordUrl,
+  speakerApplyUrl,
+  telegramUrl,
+  tickSiteUrl,
+  xUrl,
+} from "@/public/constant/urls";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import styles from "@/components/HomePage/Home2026.module.css";
+
+type NavItem = {
+  label: string;
+  href?: string;
+  external?: boolean;
+  disabled?: boolean;
+};
+
+const navItems: NavItem[] = [
+  { label: "Home", href: "/#home" },
+  { label: "Agenda", disabled: true },
+  { label: "Events", href: "/#events" },
+  { label: "Apply", href: speakerApplyUrl, external: true },
+  { label: "Venue", href: "/#venue" },
+  { label: "Community", href: "/#community" },
+  { label: "Visa", href: "/visainfo#info" },
+];
+
+const socialLinks = [
+  { label: "Discord", href: discordUrl, icon: "/images/social-icons/discord_icon.svg" },
+  { label: "X", href: xUrl, icon: "/images/social-icons/x_icon.svg" },
+  { label: "Telegram", href: telegramUrl, icon: "/images/social-icons/telegram_icon.svg" },
+];
+
+const Star = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      d="M12 1 14.5 9.5 23 12l-8.5 2.5L12 23l-2.5-8.5L1 12l8.5-2.5L12 1Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const SocialLinks = ({ className = "" }: { className?: string }) => (
+  <div className={`${styles.socialLinks} ${className}`} aria-label="ETHTaipei social links">
+    {socialLinks.map((item) => (
+      <a
+        className={styles.socialLink}
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`ETHTaipei on ${item.label}`}
+        key={item.label}
+      >
+        <Image src={item.icon} alt="" width={24} height={24} />
+      </a>
+    ))}
+  </div>
+);
+
+const NavLinks = ({
+  activeHref,
+  onNavigate,
+}: {
+  activeHref: string;
+  onNavigate?: () => void;
+}) => (
+  <>
+    {navItems.map((item) => {
+      if (item.disabled) {
+        return (
+          <span
+            key={item.label}
+            className={styles.navDisabled}
+            aria-disabled="true"
+            aria-label={`${item.label}, to be announced`}
+          >
+            <span>{item.label}</span>
+            <span className={styles.navTba} aria-hidden="true">TBA</span>
+          </span>
+        );
+      }
+
+      if (!item.href) return null;
+      const className = activeHref === item.href ? styles.navActive : undefined;
+
+      return item.external ? (
+        <a
+          className={className}
+          key={item.label}
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onNavigate}
+        >
+          {item.label}
+        </a>
+      ) : (
+        <Link className={className} key={item.label} href={item.href} onClick={onNavigate}>
+          {item.label}
+        </Link>
+      );
+    })}
+  </>
+);
+
+const Header2026 = ({ activeHref }: { activeHref: string }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    const closeOnDesktop = () => {
+      if (window.innerWidth > 980) setMenuOpen(false);
+    };
+
+    window.addEventListener("keydown", closeOnEscape);
+    window.addEventListener("resize", closeOnDesktop);
+    return () => {
+      window.removeEventListener("keydown", closeOnEscape);
+      window.removeEventListener("resize", closeOnDesktop);
+    };
+  }, []);
+
+  return (
+    <>
+      <header className={styles.topbar}>
+        <Link className={styles.brand} href="/#home" aria-label="ETHTaipei home">
+          <Star className={styles.brandMark} />
+          <span>ETHTaipei</span>
+        </Link>
+        <nav className={styles.nav} aria-label="Primary navigation">
+          <NavLinks activeHref={activeHref} />
+        </nav>
+        <div className={styles.topbarActions}>
+          <SocialLinks />
+          <a className={styles.ticket} href={tickSiteUrl} target="_blank" rel="noreferrer">
+            Buy Ticket
+          </a>
+        </div>
+        <button
+          className={styles.menuToggle}
+          type="button"
+          aria-expanded={menuOpen}
+          aria-controls="mobile-nav"
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          {menuOpen ? (
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m6 6 12 12M18 6 6 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M4 7h16M4 12h16M4 17h16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          )}
+        </button>
+      </header>
+
+      <nav
+        className={`${styles.mobileNav} ${menuOpen ? styles.mobileNavOpen : ""}`}
+        id="mobile-nav"
+        aria-label="Mobile navigation"
+      >
+        <NavLinks activeHref={activeHref} onNavigate={() => setMenuOpen(false)} />
+        <SocialLinks className={styles.mobileSocialLinks} />
+      </nav>
+    </>
+  );
+};
+
+export default Header2026;

--- a/components/VisaInfoPage/VisaInfoPage.module.css
+++ b/components/VisaInfoPage/VisaInfoPage.module.css
@@ -1,0 +1,212 @@
+.page {
+  position: relative;
+  min-height: 100svh;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 12% 18%, rgb(203 241 1 / 0.13), transparent 28rem),
+    radial-gradient(circle at 86% 24%, oklch(59% 0.22 266 / 0.2), transparent 30rem),
+    linear-gradient(180deg, oklch(10% 0.027 255), oklch(7% 0.018 255));
+}
+
+.main {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 100svh;
+  padding: calc(var(--nav-h) + 72px) clamp(20px, 6vw, 88px) 96px;
+  scroll-margin-top: var(--nav-h);
+}
+
+.main::before {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  content: "";
+  opacity: 0.28;
+  background-image:
+    linear-gradient(rgb(203 241 1 / 0.18) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(203 241 1 / 0.18) 1px, transparent 1px);
+  background-position: center;
+  background-size: 46px 46px;
+  mask-image: radial-gradient(110% 100% at 50% 40%, black 28%, transparent 82%);
+}
+
+.main::after {
+  position: absolute;
+  top: 16%;
+  right: -10%;
+  z-index: -1;
+  width: min(48vw, 620px);
+  aspect-ratio: 1;
+  content: "";
+  opacity: 0.07;
+  background:
+    linear-gradient(45deg, transparent 42%, #cbf101 42% 58%, transparent 58%),
+    linear-gradient(-45deg, transparent 42%, #cbf101 42% 58%, transparent 58%);
+  transform: rotate(12deg);
+}
+
+.shell {
+  width: min(100%, 1080px);
+  margin: 0 auto;
+}
+
+.intro {
+  max-width: 820px;
+}
+
+.eyebrow {
+  margin: 0 0 18px;
+  color: var(--acid);
+  font-size: clamp(13px, 1.3vw, 16px);
+  font-weight: 600;
+  letter-spacing: 0.22em;
+}
+
+.title {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(64px, 9vw, 118px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 0.86;
+  text-shadow:
+    0 2px 3px oklch(0% 0 0 / 0.55),
+    0 14px 34px oklch(0% 0 0 / 0.62);
+}
+
+.title span {
+  color: var(--acid);
+  text-shadow: 0 0 34px rgb(203 241 1 / 0.5);
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+  margin-top: clamp(52px, 7vw, 82px);
+}
+
+.card {
+  position: relative;
+  min-height: 310px;
+  padding: clamp(28px, 4vw, 42px);
+  overflow: hidden;
+  border: 1px solid oklch(96% 0.018 126 / 0.16);
+  border-radius: 4px 24px 4px 24px;
+  background:
+    linear-gradient(135deg, rgb(203 241 1 / 0.07), transparent 42%, rgb(57 82 255 / 0.1)),
+    oklch(12% 0.027 255 / 0.84);
+  box-shadow:
+    inset 0 0 0 1px oklch(0% 0 0 / 0.34),
+    0 24px 60px -38px rgb(0 0 0 / 0.9);
+  backdrop-filter: blur(16px);
+}
+
+.card::before {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  content: "";
+  opacity: 0.13;
+  background-image:
+    linear-gradient(rgb(203 241 1 / 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(203 241 1 / 0.16) 1px, transparent 1px);
+  background-size: 20px 20px;
+  mask-image: linear-gradient(135deg, black, transparent 68%);
+}
+
+.card::after {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  content: "";
+  background: linear-gradient(90deg, var(--acid), var(--blue), var(--amber));
+}
+
+.cardNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 46px;
+  min-height: 30px;
+  padding: 4px 9px;
+  border: 1px solid rgb(203 241 1 / 0.36);
+  border-radius: 4px 10px 4px 10px;
+  color: var(--acid);
+  background: rgb(203 241 1 / 0.08);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.card h2 {
+  max-width: 18ch;
+  margin: 30px 0 18px;
+  color: var(--ink);
+  font-size: clamp(27px, 3vw, 38px);
+  font-weight: 700;
+  line-height: 1.06;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  font-size: clamp(16px, 1.5vw, 18px);
+  line-height: 1.7;
+}
+
+.link {
+  color: var(--acid);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: rgb(203 241 1 / 0.42);
+  text-underline-offset: 4px;
+  transition: color 0.18s ease, text-decoration-color 0.18s ease;
+}
+
+.link:hover {
+  color: white;
+  text-decoration-color: var(--acid);
+}
+
+.link:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--acid);
+  outline-offset: 3px;
+}
+
+@media (max-width: 760px) {
+  .main {
+    align-items: flex-start;
+    padding: calc(var(--nav-h) + 54px) 18px 72px;
+  }
+
+  .cards {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    margin-top: 46px;
+  }
+
+  .card {
+    min-height: 0;
+    padding: 28px 24px 30px;
+    border-radius: 4px 18px 4px 18px;
+  }
+
+  .card h2 {
+    margin-top: 24px;
+  }
+}
+
+@media (max-width: 420px) {
+  .title {
+    font-size: clamp(58px, 20vw, 78px);
+  }
+
+  .eyebrow {
+    letter-spacing: 0.16em;
+  }
+}

--- a/components/VisaInfoPage/index.tsx
+++ b/components/VisaInfoPage/index.tsx
@@ -1,76 +1,61 @@
+import Header2026 from "@/components/Layout/Header2026";
 import t from "@/public/constant/content";
-import Colors from "@/styles/colors";
-import styled from "styled-components";
 import {
   invitationLetterUrl,
   telegramUrl,
   visaUrl,
 } from "@/public/constant/urls";
-import { useRouting } from "@/public/utils/common";
 
-const VisaInfoPage = () => {
-  const { handleOnClickExternalLink } = useRouting();
+import homeStyles from "@/components/HomePage/Home2026.module.css";
+import styles from "./VisaInfoPage.module.css";
 
-  return (
-    <Container id="info">
-      <Question>{t.visa.visaQuestion1}</Question>
-      <Description>
-        {t.visa.visaAnswer1Part1}
-        <Link onClick={() => handleOnClickExternalLink(visaUrl)}>
-          {t.visa.BureauOfConsularAffairs}
-        </Link>
-        {t.visa.visaAnswer1Part2}
-      </Description>
+const ExternalLink = ({ href, children }: { href: string; children: React.ReactNode }) => (
+  <a className={styles.link} href={href} target="_blank" rel="noopener noreferrer">
+    {children}
+  </a>
+);
 
-      <Question>{t.visa.visaQuestion2}</Question>
-      <Description>
-        {t.visa.visaAnswer2Part1}
-        <br />
-        {t.visa.visaAnswer2Part2}
-        <Link onClick={() => handleOnClickExternalLink(invitationLetterUrl)}>
-          {t.visa.form}
-        </Link>
-        {t.visa.visaAnswer2Part3}
-        <Link onClick={() => handleOnClickExternalLink(telegramUrl)}>
-          {t.visa.telegram}
-        </Link>
-        {t.visa.visaAnswer2Part4}
-      </Description>
-    </Container>
-  );
-};
+const VisaInfoPage = () => (
+  <div className={`${homeStyles.page} ${styles.page}`}>
+    <Header2026 activeHref="/visainfo#info" />
+
+    <main className={styles.main} id="info">
+      <div className={styles.shell}>
+        <header className={styles.intro}>
+          <p className={styles.eyebrow}>ETHTAIPEI · TRAVEL INFO</p>
+          <h1 className={styles.title}>
+            Visa <span>Info</span>
+          </h1>
+        </header>
+
+        <section className={styles.cards} aria-label="Taiwan visa information">
+          <article className={styles.card}>
+            <span className={styles.cardNumber} aria-hidden="true">01</span>
+            <h2>{t.visa.visaQuestion1}</h2>
+            <p>
+              {t.visa.visaAnswer1Part1}
+              <ExternalLink href={visaUrl}>{t.visa.BureauOfConsularAffairs}</ExternalLink>
+              {t.visa.visaAnswer1Part2}
+            </p>
+          </article>
+
+          <article className={styles.card}>
+            <span className={styles.cardNumber} aria-hidden="true">02</span>
+            <h2>{t.visa.visaQuestion2}</h2>
+            <p>
+              {t.visa.visaAnswer2Part1}
+              <br />
+              {t.visa.visaAnswer2Part2}
+              <ExternalLink href={invitationLetterUrl}>{t.visa.form}</ExternalLink>
+              {t.visa.visaAnswer2Part3}
+              <ExternalLink href={telegramUrl}>{t.visa.telegram}</ExternalLink>
+              {t.visa.visaAnswer2Part4}
+            </p>
+          </article>
+        </section>
+      </div>
+    </main>
+  </div>
+);
+
 export default VisaInfoPage;
-
-const Container = styled.div`
-  width: 100%;
-  max-width: 800px;
-  margin: auto;
-  padding: 120px 40px;
-  justify-content: center;
-  @media (max-width: 768px) {
-    padding: 60px 24px;
-  }
-`;
-
-const Question = styled.h2`
-  font-size: 30px;
-  font-weight: bold;
-  line-height: 30px;
-  color: ${Colors.brightBlue};
-  margin-bottom: 10px;
-  margin-top: 40px;
-`;
-
-const Description = styled.div`
-  font-size: 18px;
-  line-height: 24px;
-  margin-bottom: 10px;
-  color: black;
-`;
-
-const Link = styled.a`
-  color: ${Colors.brightBlue};
-  :hover {
-    color: ${Colors.neonGreen};
-  }
-`;

--- a/pages/visainfo/index.tsx
+++ b/pages/visainfo/index.tsx
@@ -1,10 +1,9 @@
 import VisaInfoPage from "@/components/VisaInfoPage";
-import Layout from "@/components/Layout";
 
 const VisaInfo = () => {
   return <VisaInfoPage />;
 };
 
-VisaInfo.getLayout = (page: React.ReactNode) => <Layout>{page}</Layout>;
+VisaInfo.getLayout = (page: React.ReactNode) => page;
 
 export default VisaInfo;

--- a/public/constant/flags.ts
+++ b/public/constant/flags.ts
@@ -11,4 +11,5 @@ export const FLAGS = {
   showTickets: false,
   showApplyCTAs: false,
   showSideEvents: false,
+  showCommunityCalendar: false,
 };


### PR DESCRIPTION
## Summary

  - Refresh the homepage social dock and mobile countdown layout.
  - Add a branded empty state when no community events are available.
  - Redesign the Visa Info page to match the ETHTaipei 2026 visual style.
  - Add a reusable 2026 header for internal pages.