### PR TITLE
feat: two-day agenda page (/agenda) in the 2026 site style

### DIFF
--- a/components/AgendaPage2026/AgendaPage2026.module.css
+++ b/components/AgendaPage2026/AgendaPage2026.module.css
@@ -1,0 +1,481 @@
+.page {
+  /* Header2026's fixed topbar sizes off --site-nav-height, which is normally
+     set on .home-2026. This page isn't wrapped in that class, so define it here
+     or the nav-height calc collapses and content slides under the header. */
+  --site-nav-height: 76px;
+  --day-accent: var(--acid);
+  --day-accent-soft: rgb(203 241 1 / 0.42);
+  position: relative;
+  min-height: 100svh;
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(circle at 12% 16%, rgb(203 241 1 / 0.12), transparent 28rem),
+    radial-gradient(circle at 88% 22%, oklch(59% 0.22 266 / 0.18), transparent 30rem),
+    linear-gradient(180deg, oklch(10% 0.027 255), oklch(7% 0.018 255));
+  transition: background 0.4s ease;
+}
+
+.page[data-day="day2"] {
+  --day-accent: var(--amber);
+  --day-accent-soft: oklch(78% 0.18 70 / 0.42);
+  background:
+    radial-gradient(circle at 12% 16%, oklch(78% 0.18 70 / 0.12), transparent 28rem),
+    radial-gradient(circle at 88% 22%, oklch(59% 0.22 266 / 0.18), transparent 30rem),
+    linear-gradient(180deg, oklch(10% 0.027 255), oklch(7% 0.018 255));
+}
+
+.main {
+  position: relative;
+  min-height: 100svh;
+  padding: calc(var(--nav-h) + 64px) clamp(20px, 6vw, 88px) 112px;
+  scroll-margin-top: var(--nav-h);
+}
+
+.main::before {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  content: "";
+  opacity: 0.22;
+  background-image:
+    linear-gradient(rgb(203 241 1 / 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(203 241 1 / 0.16) 1px, transparent 1px);
+  background-position: center;
+  background-size: 46px 46px;
+  mask-image: radial-gradient(120% 90% at 50% 20%, black 26%, transparent 82%);
+}
+
+.shell {
+  width: min(100%, 1080px);
+  margin: 0 auto;
+}
+
+/* ---------- Intro ---------- */
+.intro {
+  max-width: 860px;
+}
+
+.eyebrow {
+  margin: 0 0 18px;
+  color: var(--day-accent);
+  font-size: clamp(13px, 1.3vw, 16px);
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  transition: color 0.3s ease;
+}
+
+.title {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(56px, 8vw, 104px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 0.88;
+  text-shadow:
+    0 2px 3px oklch(0% 0 0 / 0.55),
+    0 14px 34px oklch(0% 0 0 / 0.62);
+}
+
+.title span {
+  color: var(--day-accent);
+  text-shadow: 0 0 34px var(--day-accent-soft);
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+
+.lede {
+  max-width: 680px;
+  margin: 26px 0 0;
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  font-size: clamp(15px, 1.5vw, 18px);
+  line-height: 1.7;
+}
+
+.lede b {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+/* ---------- Day tabs ---------- */
+.dayTabs {
+  position: sticky;
+  top: var(--nav-h);
+  z-index: 5;
+  display: flex;
+  gap: 12px;
+  margin: clamp(40px, 6vw, 64px) 0 8px;
+  padding: 14px 0;
+  background: linear-gradient(180deg, var(--night) 62%, transparent);
+}
+
+.dayTab {
+  flex: 1;
+  padding: 16px 18px;
+  border: 1px solid var(--panel-line);
+  border-radius: 4px 16px 4px 16px;
+  background: oklch(14% 0.025 255 / 0.6);
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.18s ease;
+  backdrop-filter: blur(12px);
+}
+
+.dayTab:hover {
+  color: var(--ink);
+  border-color: oklch(96% 0.018 126 / 0.32);
+  transform: translateY(-2px);
+}
+
+.dayTabDate {
+  display: block;
+  font-family: "Menlo", monospace;
+  font-size: clamp(18px, 2.4vw, 24px);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.dayTabName {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.dayTab[aria-selected="true"] {
+  color: var(--night);
+  background: var(--acid);
+  border-color: var(--acid);
+}
+
+.dayTab[aria-selected="true"]:nth-child(2) {
+  background: var(--amber);
+  border-color: var(--amber);
+}
+
+.dayTab:focus-visible {
+  outline: 2px solid var(--day-accent);
+  outline-offset: 3px;
+}
+
+/* ---------- Panels ---------- */
+.panel {
+  animation: fade 0.32s ease;
+}
+
+@keyframes fade {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.bandCard {
+  position: relative;
+  overflow: hidden;
+  margin-top: 20px;
+  padding: clamp(24px, 3.4vw, 34px);
+  border: 1px solid var(--panel-line);
+  border-left: 4px solid var(--acid);
+  border-radius: 4px 20px 4px 20px;
+  background:
+    linear-gradient(135deg, rgb(203 241 1 / 0.07), transparent 46%, rgb(57 82 255 / 0.08)),
+    oklch(12% 0.027 255 / 0.82);
+  backdrop-filter: blur(16px);
+}
+
+.bandCardAlt {
+  border-left-color: var(--amber);
+  background:
+    linear-gradient(135deg, oklch(78% 0.18 70 / 0.08), transparent 46%, rgb(57 82 255 / 0.08)),
+    oklch(12% 0.027 255 / 0.82);
+}
+
+.bandCard::after {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  content: "";
+  background: linear-gradient(90deg, var(--acid), var(--blue), var(--amber));
+}
+
+.bandTag {
+  font-family: "Menlo", monospace;
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.bandName {
+  margin: 10px 0 8px;
+  color: var(--ink);
+  font-size: clamp(24px, 3vw, 34px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.bandSub {
+  max-width: 720px;
+  margin: 0;
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  font-size: clamp(14px, 1.4vw, 16px);
+  line-height: 1.65;
+}
+
+.sectionLabel {
+  margin: 40px 0 0;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--panel-line);
+  color: var(--day-accent);
+  font-family: "Menlo", monospace;
+  font-size: 13px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+/* ---------- Pillars (Day 1) ---------- */
+.pillars {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(248px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.pillar {
+  position: relative;
+  overflow: hidden;
+  padding: 24px 22px 26px;
+  border: 1px solid var(--panel-line);
+  border-top: 2px solid var(--acid);
+  border-radius: 4px 14px 4px 14px;
+  background:
+    linear-gradient(135deg, rgb(203 241 1 / 0.05), transparent 60%),
+    oklch(13% 0.025 255 / 0.7);
+  transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.pillar:hover {
+  transform: translateY(-3px);
+  background:
+    linear-gradient(135deg, rgb(203 241 1 / 0.1), transparent 60%),
+    oklch(15% 0.025 255 / 0.8);
+}
+
+.pillarNum {
+  font-family: "Menlo", monospace;
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  color: oklch(78% 0.16 122);
+}
+
+.pillarTitle {
+  margin: 10px 0 0;
+  color: var(--ink);
+  font-size: 19px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.pillarDesc {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+
+/* ---------- Sessions & slots (Day 2) ---------- */
+.session {
+  margin-top: 44px;
+}
+
+.sessionHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 14px;
+  border-bottom: 2px solid var(--amber);
+  margin-bottom: 4px;
+}
+
+.sessionHead h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(18px, 2.2vw, 23px);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.sessionRange {
+  font-family: "Menlo", monospace;
+  font-size: 14px;
+  color: var(--amber);
+  white-space: nowrap;
+}
+
+.slot {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 20px;
+  padding: 22px 4px;
+  border-bottom: 1px solid var(--panel-line);
+  transition: background 0.15s ease;
+}
+
+.slot:hover {
+  background: oklch(78% 0.18 70 / 0.04);
+}
+
+.slotTime {
+  font-family: "Menlo", monospace;
+  font-size: 14px;
+  color: var(--ink);
+  padding-top: 2px;
+  white-space: nowrap;
+}
+
+.slotDur {
+  display: block;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.slotTitle {
+  margin: 0 0 8px;
+  color: var(--ink);
+  font-size: clamp(16px, 1.7vw, 18px);
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.slotDesc {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.slotFooter {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+}
+
+.slotPanel {
+  border-left: 2px solid var(--amber);
+  padding-left: 16px;
+  background: oklch(78% 0.18 70 / 0.05);
+}
+
+.slotPanel:hover {
+  background: oklch(78% 0.18 70 / 0.08);
+}
+
+.fmt {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-family: "Menlo", monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fmtTalk {
+  background: oklch(78% 0.18 70 / 0.16);
+  color: var(--amber);
+}
+
+.fmtPanel {
+  background: var(--amber);
+  color: var(--night);
+}
+
+.tag {
+  display: inline-block;
+  padding: 3px 10px;
+  border: 1px solid var(--blue);
+  border-radius: 999px;
+  color: oklch(72% 0.16 266);
+  font-family: "Menlo", monospace;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+}
+
+/* ---------- Break ---------- */
+.break {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 20px;
+  padding: 16px 4px;
+  border-bottom: 1px solid var(--panel-line);
+}
+
+.breakLabel {
+  align-self: center;
+  color: var(--amber);
+  font-family: "Menlo", monospace;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* ---------- Note ---------- */
+.note {
+  margin-top: 40px;
+  padding: 18px 22px;
+  border: 1px dashed var(--panel-line);
+  border-radius: 4px 12px 4px 12px;
+  color: var(--muted);
+  font-family: "Inter", ui-sans-serif, sans-serif;
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.note b {
+  color: var(--day-accent);
+  font-weight: 600;
+}
+
+@media (max-width: 980px) {
+  .page {
+    --site-nav-height: 70px;
+  }
+}
+
+@media (max-width: 760px) {
+  .main {
+    padding: calc(var(--nav-h) + 44px) 18px 84px;
+  }
+
+  .slot,
+  .break {
+    grid-template-columns: 66px 1fr;
+    gap: 14px;
+  }
+
+  .sessionHead {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+
+@media (max-width: 420px) {
+  .title {
+    font-size: clamp(48px, 16vw, 66px);
+  }
+
+  .dayTab {
+    padding: 13px 14px;
+  }
+}

--- a/components/AgendaPage2026/index.tsx
+++ b/components/AgendaPage2026/index.tsx
@@ -1,0 +1,289 @@
+import Header2026 from "@/components/Layout/Header2026";
+import { useState } from "react";
+
+import homeStyles from "@/components/HomePage/Home2026.module.css";
+import styles from "./AgendaPage2026.module.css";
+
+type DayId = "day1" | "day2";
+
+type Pillar = {
+  n: string;
+  title: string;
+  desc: string;
+};
+
+type Slot = {
+  time: string;
+  dur: string;
+  title: string;
+  desc: string;
+  format: "talk" | "panel";
+  tag: string;
+};
+
+type Session = {
+  heading: string;
+  range: string;
+  slots: Slot[];
+};
+
+const PILLARS: Pillar[] = [
+  {
+    n: "01",
+    title: "Protocol & Core Dev",
+    desc: "Consensus, execution- and consensus-layer clients, EIPs, and the road to the next hard fork.",
+  },
+  {
+    n: "02",
+    title: "L2s & Scaling",
+    desc: "Rollups, shared sequencing, interop, data availability, and seamless cross-L2 UX.",
+  },
+  {
+    n: "03",
+    title: "ZK & Privacy",
+    desc: "Proving systems, zkEVMs, coprocessors, and privacy-preserving applications.",
+  },
+  {
+    n: "04",
+    title: "Wallets & Account Abstraction",
+    desc: "Smart accounts, ERC-4337 / 7702, passkeys, and gasless UX.",
+  },
+  {
+    n: "05",
+    title: "DeFi",
+    desc: "AMMs, lending, stablecoins, intents, and on-chain risk management.",
+  },
+  {
+    n: "06",
+    title: "Consumer & Social",
+    desc: "On-chain social, gaming, payments, and apps built for everyday users.",
+  },
+  {
+    n: "07",
+    title: "Security",
+    desc: "Auditing, formal verification, MEV, and keeping users and protocols safe.",
+  },
+  {
+    n: "08",
+    title: "Infra & Tooling",
+    desc: "RPC, indexing, dev frameworks, and oracles — the plumbing builders rely on.",
+  },
+];
+
+const INSTITUTION_SESSIONS: Session[] = [
+  {
+    heading: "Morning · Custody / Wallet",
+    range: "10:00 – 12:00",
+    slots: [
+      {
+        time: "10:00",
+        dur: "30 min",
+        title:
+          "From Smart Accounts to Compliant Accounts: The Future of Institutional Wallets",
+        desc: "How the wallet stack is evolving — authentication, roles and permissions, transaction policy, real-time risk checks, audit trails, and compliance modules — into the next generation of institutional wallets.",
+        format: "talk",
+        tag: "Custody / Wallets",
+      },
+      {
+        time: "10:30",
+        dur: "30 min",
+        title: "Security in Digital Assets & Smart Contracts",
+        desc: "Web3 security across the stack — from safeguarding assets and hardening smart contracts to securing surrounding infrastructure and protecting staff from social engineering.",
+        format: "talk",
+        tag: "Security",
+      },
+      {
+        time: "11:00",
+        dur: "60 min",
+        title:
+          "Panel — Stablecoin Types & Risk Management: USDC / USDT / OUSD / DAI / USDe",
+        desc: "Perspectives on the major stablecoins in the market, their stability mechanisms, and how to classify their risks.",
+        format: "panel",
+        tag: "Stablecoins",
+      },
+    ],
+  },
+  {
+    heading: "Afternoon · RWA / Tokenized Stocks",
+    range: "13:00 – 16:00",
+    slots: [
+      {
+        time: "13:00",
+        dur: "30 min",
+        title:
+          "How Are Tokenized US Stocks Issued? Three Models, from Ondo to xStocks",
+        desc: "Using Ondo Global Markets as the anchor case — compared with Backed Finance (xStocks) and Dinari — we break down three key differences behind tokenized US equities: collateral & custody architecture, regulatory jurisdiction, and investor eligibility & liquidity design.",
+        format: "talk",
+        tag: "RWA / Stocks",
+      },
+      {
+        time: "13:30",
+        dur: "30 min",
+        title:
+          "Positioning for the Trillion-Dollar “Machine Finance” Market of Autonomous AI Agents",
+        desc: "Starting from x402 (backed by the Linux Foundation and others), how autonomous AI agents pay and transact on-chain — and what this “machine finance” market means for financial institutions.",
+        format: "talk",
+        tag: "AI / Machine Finance",
+      },
+      {
+        time: "14:00",
+        dur: "60 min",
+        title: "Panel — Tokenization Progress at Traditional Finance Giants",
+        desc: "Representatives from traditional financial infrastructure — NYSE, Nasdaq, SWIFT and others — share where they are on tokenization, the regulatory and technical challenges they face, and their outlook for the next 3–5 years.",
+        format: "panel",
+        tag: "Tokenization",
+      },
+      {
+        time: "15:00",
+        dur: "60 min",
+        title:
+          "Panel — Private vs. Public Chains: The Real Decision Axes for Institutions",
+        desc: "Breaking the debate into the axes that actually matter — data privacy, regulatory control, finality guarantees, liquidity access, and vendor lock-in — rather than a vague notion of “security.” Where Besu / Canton / Prividium / public chains each stand.",
+        format: "panel",
+        tag: "Chain Selection",
+      },
+    ],
+  },
+];
+
+const DAYS: { id: DayId; date: string; name: string }[] = [
+  { id: "day1", date: "SEP 13", name: "Cryptonative Day" },
+  { id: "day2", date: "SEP 14", name: "Institution Day" },
+];
+
+const AgendaPage2026 = () => {
+  const [activeDay, setActiveDay] = useState<DayId>("day1");
+
+  return (
+    <div className={`${homeStyles.page} ${styles.page}`} data-day={activeDay}>
+      <Header2026 activeHref="/agenda" />
+
+      <main className={styles.main} id="agenda">
+        <div className={styles.shell}>
+          <header className={styles.intro}>
+            <p className={styles.eyebrow}>ETHTAIPEI 2026 · AGENDA</p>
+            <h1 className={styles.title}>
+              Agenda<span>.</span>
+            </h1>
+            <p className={styles.lede}>
+              Two days at ETHTaipei 2026: <b>Sep 13 — Cryptonative Day</b> belongs to
+              the Ethereum builder community; <b>Sep 14 — Institution Day</b> is built
+              for banks and financial institutions. This is a draft — topics and timing
+              may change.
+            </p>
+          </header>
+
+          <div className={styles.dayTabs} role="tablist" aria-label="Agenda days">
+            {DAYS.map((day) => (
+              <button
+                key={day.id}
+                className={styles.dayTab}
+                type="button"
+                role="tab"
+                aria-selected={activeDay === day.id}
+                onClick={() => setActiveDay(day.id)}
+              >
+                <span className={styles.dayTabDate}>{day.date}</span>
+                <span className={styles.dayTabName}>{day.name}</span>
+              </button>
+            ))}
+          </div>
+
+          {activeDay === "day1" ? (
+            <section className={styles.panel} aria-label="Cryptonative Day">
+              <div className={styles.bandCard}>
+                <span className={styles.bandTag}>Day 01 · Sep 13 · Main Stage</span>
+                <h2 className={styles.bandName}>Cryptonative Day</h2>
+                <p className={styles.bandSub}>
+                  A day for the Ethereum builder community — from core protocol to
+                  consumer apps. Full schedule and speaker lineup in progress.
+                </p>
+              </div>
+
+              <p className={styles.sectionLabel}>What to Expect</p>
+              <div className={styles.pillars}>
+                {PILLARS.map((pillar) => (
+                  <article className={styles.pillar} key={pillar.n}>
+                    <span className={styles.pillarNum} aria-hidden="true">
+                      {pillar.n}
+                    </span>
+                    <h3 className={styles.pillarTitle}>{pillar.title}</h3>
+                    <p className={styles.pillarDesc}>{pillar.desc}</p>
+                  </article>
+                ))}
+              </div>
+
+              <p className={styles.note}>
+                <b>Schedule in progress.</b> The full timetable, talk titles, and
+                speakers will be announced once the lineup is confirmed. Above are the
+                themes this day is expected to cover.
+              </p>
+            </section>
+          ) : (
+            <section className={styles.panel} aria-label="Institution Day">
+              <div className={`${styles.bandCard} ${styles.bandCardAlt}`}>
+                <span className={styles.bandTag}>Day 02 · Sep 14 · Main Stage</span>
+                <h2 className={styles.bandName}>Institution Day</h2>
+                <p className={styles.bandSub}>
+                  A one-day track built for banks and financial institutions — the
+                  morning on institutional-grade custody and wallet architecture, the
+                  afternoon on RWA and tokenized-equity practice and chain selection.
+                  Single track · Main Stage.
+                </p>
+              </div>
+
+              {INSTITUTION_SESSIONS.map((session) => (
+                <div className={styles.session} key={session.heading}>
+                  <div className={styles.sessionHead}>
+                    <h2>{session.heading}</h2>
+                    <span className={styles.sessionRange}>{session.range}</span>
+                  </div>
+                  {session.slots.map((slot) => (
+                    <div
+                      className={`${styles.slot} ${
+                        slot.format === "panel" ? styles.slotPanel : ""
+                      }`}
+                      key={slot.time + slot.title}
+                    >
+                      <div className={styles.slotTime}>
+                        {slot.time}
+                        <span className={styles.slotDur}>{slot.dur}</span>
+                      </div>
+                      <div>
+                        <p className={styles.slotTitle}>{slot.title}</p>
+                        <p className={styles.slotDesc}>{slot.desc}</p>
+                        <div className={styles.slotFooter}>
+                          <span
+                            className={`${styles.fmt} ${
+                              slot.format === "panel" ? styles.fmtPanel : styles.fmtTalk
+                            }`}
+                          >
+                            {slot.format === "panel" ? "Panel" : "Talk"}
+                          </span>
+                          <span className={styles.tag}>{slot.tag}</span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                  {session.range === "10:00 – 12:00" && (
+                    <div className={styles.break}>
+                      <div className={styles.slotTime}>12:00</div>
+                      <div className={styles.breakLabel}>Lunch &amp; Networking</div>
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              <p className={styles.note}>
+                <b>Tentative schedule.</b> Topics and timing may change; the speaker
+                lineup will be announced once confirmed.
+              </p>
+            </section>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default AgendaPage2026;

--- a/components/HomePage/Home2026.tsx
+++ b/components/HomePage/Home2026.tsx
@@ -30,7 +30,7 @@ type NavItem = {
 
 const navItems: NavItem[] = [
   { label: "Home", href: "#home" },
-  { label: "Agenda", disabled: true },
+  { label: "Agenda", href: "/agenda" },
   { label: "Events", href: "#events" },
   { label: "Apply", href: speakerApplyUrl, external: true },
   { label: "Venue", href: "#venue" },

--- a/components/Layout/Header2026.tsx
+++ b/components/Layout/Header2026.tsx
@@ -20,7 +20,7 @@ type NavItem = {
 
 const navItems: NavItem[] = [
   { label: "Home", href: "/#home" },
-  { label: "Agenda", disabled: true },
+  { label: "Agenda", href: "/agenda" },
   { label: "Events", href: "/#events" },
   { label: "Apply", href: speakerApplyUrl, external: true },
   { label: "Venue", href: "/#venue" },

--- a/pages/agenda/index.tsx
+++ b/pages/agenda/index.tsx
@@ -1,15 +1,9 @@
-import Agendas from "@/components/AgendaPage/Agendas";
-import Layout from "@/components/Layout";
-import { ApolloWrapper } from "@/components/providers/apollo";
+import AgendaPage2026 from "@/components/AgendaPage2026";
 
 const Agenda = () => {
-  return (
-    <ApolloWrapper pageProps={{ initialApolloState: null }}>
-      <Agendas />
-    </ApolloWrapper>
-  );
+  return <AgendaPage2026 />;
 };
 
-Agenda.getLayout = (page: React.ReactNode) => <Layout>{page}</Layout>;
+Agenda.getLayout = (page: React.ReactNode) => page;
 
 export default Agenda;


### PR DESCRIPTION
## Summary
Adds a real **`/agenda`** page built with the site's own 2026 design system (not the standalone guide HTML). Two days with a tab switcher:

- **Sep 13 — Cryptonative Day** (acid/lime theme): 8 thematic pillars ("what to expect"), no times/talks/speakers, since the agenda isn't set yet.
- **Sep 14 — Institution Day** (amber theme): the tentative schedule (Custody/Wallet morning, RWA/Tokenized-stocks afternoon) as slot rows with Talk/Panel pills, topic tags, and a lunch break. **No speakers listed.**

Switching days re-tints the whole page (background glow, accents, pills).

## Changes
- **`components/AgendaPage2026/`** *(new)* — `index.tsx` (client component with day-tab state) + `AgendaPage2026.module.css`, reusing the `Home2026.module.css .page` design tokens and following the `VisaInfoPage` sub-page pattern (Header2026 + styled `main`).
- **`pages/agenda/index.tsx`** — repointed from the old Hygraph-driven placeholder (`AgendaPage/Agendas`) to the new component.
- **`components/Layout/Header2026.tsx`** & **`components/HomePage/Home2026.tsx`** — enabled the "Agenda" nav item (was `disabled` / TBA) to link to `/agenda`.

## Notable fix
The fixed `Header2026` topbar sizes off `--site-nav-height`, which is only defined on the `.home-2026` wrapper. This page isn't wrapped in that class, so the top-padding calc collapsed and the title slid under the header. Fixed by defining `--site-nav-height` on the page (76px desktop / 70px mobile). *(Note: `VisaInfoPage` has the same latent gap but hides it by vertically centering its `main`.)*

## Notes / follow-ups
- Content is all English and marked draft.
- Internal planning material (candidate-topic backlog, "替代方案"/"Daniel" notes) was intentionally **left off** the public page; it stays in the internal guide HTML.
- The old `components/AgendaPage/` (data-driven tables) is now unused by the route but left in place — can remove in a cleanup pass.
- Agenda content is currently inlined as typed data in the component (fine for a fast-moving draft); can move to `content.ts`/Hygraph later.

## Verification
- `tsc --noEmit` clean.
- Local dev: `/agenda` and `/` compile and return 200; Day 1 renders fully in English; Day 2's English content is in the bundle; title clears the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)