### PR TITLE
fix: closed mobile menu intercepts taps on sub-pages (Institution Day → homepage)

### DIFF
--- a/components/HomePage/Home2026.module.css
+++ b/components/HomePage/Home2026.module.css
@@ -550,7 +550,11 @@
   opacity: 1;
   visibility: visible;
   transform: none;
-  pointer-events: auto;
+  /* Inherit pointer-events from .mobileNav so the submenu is only clickable
+     when the menu is open. Hardcoding `auto` here left these links hit-testable
+     while the menu was closed (display:flex + opacity:0), so taps on page
+     content behind the invisible overlay hit homepage anchor links instead. */
+  pointer-events: inherit;
 }
 
 .mobileNav .navDropdown::before {


### PR DESCRIPTION
## Problem

On the `/agenda` page in English, tapping the **Institution Day** day-tab jumped to the homepage instead of switching tabs.

## Root cause

The mobile nav is always rendered in the DOM. At ≤980px it's `display: flex` and pinned to the top of the viewport (`z-index: 99`), hidden only via `opacity: 0` + `pointer-events: none` — so taps are meant to pass through the transparent overlay to the page content behind it.

But `.mobileNav .navDropdown` hardcoded `pointer-events: auto`. Because `pointer-events` is an inherited property, this left the invisible **About** submenu links (`What is ETHTaipei / Events / Recap / Partners`, all pointing to homepage anchors like `/#about`) hit-testable **even while the menu was closed**. On `/agenda` that invisible dropdown overlays the day-tab row, so tapping "Institution Day" actually hit a hidden "→ homepage" link.

The overlap lines up in English (longer nav labels shift the layout) but not in Chinese, which is why it only reproduced in English mode.

## Fix

Change the mobile dropdown to `pointer-events: inherit` so the submenu is only clickable when the menu is open. `.mobileNavOpen` already cascades `pointer-events: auto` to the whole subtree, so opening the menu is unaffected; when closed, the dropdown now inherits `none` from its parent.

## Testing

Open `/agenda` at ≤980px with the menu closed and tap **Institution Day** — it now switches the tab instead of navigating to the homepage. Opening the mobile menu and using the About submenu still works.

Note: this app's styled-components global styles don't hydrate in the headless browser used for automated checks (body stays `display:none`), so this was verified by CSS analysis rather than a headless click test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)