### PR TITLE
fix: point ticket link to Luma

### DIFF
--- a/public/constant/urls.ts
+++ b/public/constant/urls.ts
@@ -13,7 +13,7 @@ export const sideEventApplyUrl = "";
 export const mediaPartnerApplyUrl = "";
 export const hackathonUrl = "";
 export const sideEventFormUrl = "";
-export const tickSiteUrl = "https://app.moongate.id/e/eth-taipei-2026";
+export const tickSiteUrl = "https://luma.com/8z5ys4rl";
 
 export const code4renaUrl = "https://code4rena.com/";
 export const diamondUrl = "https://dmo.finance/";


### PR DESCRIPTION
Ticketing for ETHTaipei 2026 moved from Moongate to Luma, but `tickSiteUrl` still points at the Moongate page.

This updates the single constant that every "Buy Ticket" entry point reads — hero CTA, header (desktop + mobile), the 2026 home sections, and the events block — so all of them now go to https://luma.com/8z5ys4rl.

No other Moongate reference is left in the repo.