### PR TITLE
feat: group 2026 speakers by conference day

### DIFF
--- a/components/HomePage/SpeakerSection.tsx
+++ b/components/HomePage/SpeakerSection.tsx
@@ -1,9 +1,10 @@
+import { Fragment } from "react";
 import Image from "next/image";
 import styled from "styled-components";
 
 import { useT } from "@/contexts/LanguageContext";
 import Colors from "@/styles/colors";
-import { speakers2026, Speaker2026 } from "@/public/constant/speakers2026";
+import { speakers2026ByDay, Speaker2026 } from "@/public/constant/speakers2026";
 import PeopleSection from "./PeopleSection";
 
 // Initials for the avatar fallback: first letter of the first two words.
@@ -21,7 +22,7 @@ const initials = (name: string) =>
 const SpeakerSection = () => {
   const t = useT();
 
-  if (speakers2026.length === 0) return null;
+  if (speakers2026ByDay.every((day) => day.speakers.length === 0)) return null;
 
   return (
     <PeopleSection
@@ -34,8 +35,19 @@ const SpeakerSection = () => {
       paddingStyle={{ default: "120px 40px", mobile: "60px 24px" }}
       maxWidth="1200px"
     >
-      {speakers2026.map((speaker) => (
-        <SpeakerCard key={speaker.name} speaker={speaker} />
+      {/* One flat grid, with each day's heading spanning every column, so the
+          cards of both days stay on the same column rhythm. */}
+      {speakers2026ByDay.map((day) => (
+        <Fragment key={day.id}>
+          <DayHeading>{t.homepage.speakersDays[day.id]}</DayHeading>
+          {day.speakers.length > 0 ? (
+            day.speakers.map((speaker) => (
+              <SpeakerCard key={speaker.name} speaker={speaker} />
+            ))
+          ) : (
+            <DayPlaceholder>{t.homepage.speakersLineupComingSoon}</DayPlaceholder>
+          )}
+        </Fragment>
       ))}
     </PeopleSection>
   );
@@ -70,6 +82,48 @@ const SpeakerCard = ({ speaker }: { speaker: Speaker2026 }) => (
 );
 
 export default SpeakerSection;
+
+// Full-width row inside the card grid: the day label with a hairline rule on
+// either side. `1 / -1` spans however many columns the grid currently has, so
+// this survives the responsive column changes in PeopleSection.
+const DayHeading = styled.h3`
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 20px;
+  font-weight: 600;
+  color: ${Colors.neonGreen};
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+
+  &::before,
+  &::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background-color: rgba(203, 241, 1, 0.35);
+  }
+
+  /* The first day sits directly under the section subtitle, which already has
+     the grid's top padding; later days need their own breathing room. */
+  &:not(:first-child) {
+    margin-top: 48px;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 17px;
+    gap: 12px;
+  }
+`;
+
+const DayPlaceholder = styled.p`
+  grid-column: 1 / -1;
+  margin-top: 24px;
+  text-align: center;
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.7);
+`;
 
 const Card = styled.div`
   display: flex;

--- a/public/constant/content.ts
+++ b/public/constant/content.ts
@@ -17,6 +17,12 @@ const enHomepage = {
     "ETHTaipei is hosted by the local ETH community, and we'd love to see more participants and different parties getting involved! If you have great ideas, resources, wanna host cool side events, make sure to click the Apply buttons and reach out to us through social links!",
   speakers: `${year} Speakers`,
   speakersSubtitle: "Get Ready for their expert insights!",
+  // Day names must stay in sync with the agenda page (AgendaPage2026).
+  speakersDays: {
+    cryptonative: "Sep 13 · Cryptonative Day",
+    institution: "Sep 14 · Institution Day",
+  },
+  speakersLineupComingSoon: "Lineup coming soon — stay tuned!",
   beASpeaker: "Be a Speaker",
   beASponsor: "Be a Sponsor",
   venue: "The Venue",
@@ -268,6 +274,11 @@ const zhHomepage: Dictionary["homepage"] = {
     "ETHTaipei 由在地以太坊社群共同舉辦，我們期待更多夥伴與不同角色一同參與！如果你有很棒的點子、資源，或想舉辦有趣的周邊活動，記得點擊 Apply 按鈕，並透過社群連結與我們聯繫！",
   speakers: `${year} 講者`,
   speakersSubtitle: "準備好迎接他們的專業洞見！",
+  speakersDays: {
+    cryptonative: "9/13 · 開發者日",
+    institution: "9/14 · 機構日",
+  },
+  speakersLineupComingSoon: "講者陣容即將公布，敬請期待！",
   beASpeaker: "成為講者",
   beASponsor: "成為贊助商",
   venue: "活動場地",

--- a/public/constant/speakers2026.ts
+++ b/public/constant/speakers2026.ts
@@ -6,9 +6,15 @@
 // human curation before it goes public. To refresh, re-pull from Boost and edit
 // this list.
 //
-// The Boost API does not expose speaker headshots or company logos, so cards
-// fall back to initials avatars. Fill `avatar` / `companyLogo` (paths under
-// /public/images/speakers/...) once real assets are available.
+// Company logos are not in Boost either, and not every speaker has a headshot;
+// cards fall back to an initials avatar. Fill `avatar` / `companyLogo` (paths
+// under /public/images/speakers/...) once real assets are available.
+//
+// Speakers are grouped by conference day. Boost can't tell us the day yet — its
+// sessions are still DRAFT with no start time or track — so day membership is
+// curated here by hand. The day names must match the agenda page
+// (components/AgendaPage2026/index.tsx): Sep 13 is Cryptonative Day, Sep 14 is
+// Institution Day.
 
 export type Speaker2026 = {
   name: string;
@@ -20,7 +26,15 @@ export type Speaker2026 = {
   companyLogo?: string;
 };
 
-export const speakers2026: Speaker2026[] = [
+/** Day a speaker appears on. Keys into the `speakersDays` copy in content.ts. */
+export type SpeakerDayId = "cryptonative" | "institution";
+
+export type SpeakerDay = {
+  id: SpeakerDayId;
+  speakers: Speaker2026[];
+};
+
+const cryptonativeDay: Speaker2026[] = [
   {
     name: "Aditya",
     title: "Senior Protocol Eng",
@@ -108,4 +122,13 @@ export const speakers2026: Speaker2026[] = [
   },
   // Denken Chen (ACCEPTED) — company/title are "N/A" in Boost; add once filled in.
   { name: "Denken Chen", avatar: "/images/speakers/denken-chen.png" },
+];
+
+// Sep 14. Nobody announced yet — the section renders a "coming soon" note while
+// this is empty, and switches to cards as soon as entries are added.
+const institutionDay: Speaker2026[] = [];
+
+export const speakers2026ByDay: SpeakerDay[] = [
+  { id: "cryptonative", speakers: cryptonativeDay },
+  { id: "institution", speakers: institutionDay },
 ];


### PR DESCRIPTION
Splits the speakers section into two day groups:

- **Sep 13 · Cryptonative Day** — every currently announced speaker
- **Sep 14 · Institution Day** — no announced speakers yet, so it shows its heading plus a "Lineup coming soon — stay tuned!" line

## Where the day assignment comes from

Boost can't tell us: all 19 sessions are still `DRAFT` with no `startsAt` and no `track`, so there's nothing to derive a day from. Day membership is therefore curated by hand in `speakers2026.ts`, which now exports `speakers2026ByDay` (two groups) instead of a flat `speakers2026` array. Adding a speaker to Institution Day is a one-line edit — the placeholder disappears and cards render with no code change.

## Day naming

Used **Cryptonative Day**, matching `components/AgendaPage2026/index.tsx` (`Sep 13 — Cryptonative Day` / `9/13 · 開發者日`) rather than introducing a second name for the same day. ZH copy reuses the agenda page's 開發者日 / 機構日.

## Layout

The day headings live inside the existing `PeopleSection` card grid and span `grid-column: 1 / -1`, so they stretch full width and both days keep the same column rhythm across the 4 / 3 / 2-column breakpoints. No changes to `PeopleSection`, so the other sections that use it are untouched.

## Testing

- Verified in the dev server at desktop width in **both EN and ZH** — headings, divider rules, card alignment, and the Institution Day placeholder all render correctly.
- `npm run build` succeeds; `npm test` passes (11); `tsc --noEmit` clean.
- Mobile widths not visually checked (the browser extension dropped its connection mid-check). The headings span whatever column count the grid has, and the heading font/gap shrink below 768px, so this should be fine — worth a glance on a phone before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)