### PR TITLE
feat: add booth highlights section to homepage

### DIFF
--- a/components/HomePage/Home2026.tsx
+++ b/components/HomePage/Home2026.tsx
@@ -467,6 +467,13 @@ const Hero2026 = ({ initialCfpPhase }: { initialCfpPhase: CfpPhase }) => {
               <p>{t.hero.institutionSignalText}</p>
             </div>
           </article>
+          <article className={styles.signalCard}>
+            <DottedStar className={styles.spark} id="signal-booth" />
+            <div>
+              <div className={styles.label}>{t.hero.boothSignalLabel}</div>
+              <p>{t.hero.boothSignalText}</p>
+            </div>
+          </article>
         </aside>
       </div>
 

--- a/public/constant/content.ts
+++ b/public/constant/content.ts
@@ -123,6 +123,9 @@ const enHero = {
   institutionSignalLabel: "Institution signal",
   institutionSignalText:
     "A dedicated day for banks and financial institutions — sessions and panels on custody and RWA, with closed-door discussion. Where enterprise meets the builders.",
+  boothSignalLabel: "Booth Highlights",
+  boothSignalText:
+    "Leading enterprises and active communities across the Ethereum ecosystem showcase the latest technology, products, and community achievements — a space where developers, industry partners, and communities connect and forge more cross-domain collaborations.",
   ticker: [
     "PROTOCOL RESEARCH",
     "ZK & PRIVACY",
@@ -376,6 +379,9 @@ const zhHero: Dictionary["hero"] = {
   institutionSignalLabel: "機構亮點",
   institutionSignalText:
     "為銀行與金融機構打造的專屬一天——保管與 RWA 的演講與座談，以及閉門討論。企業與開發者交會之處。",
+  boothSignalLabel: "展位亮點",
+  boothSignalText:
+    "匯聚以太坊生態指標企業與活躍社群，呈現最新技術、產品與社群成果，打造開發者、產業夥伴與社群之間的交流場域，促成更多跨域連結與合作。",
   ticker: [
     "協議研究",
     "ZK 與隱私",


### PR DESCRIPTION
在首頁右側資料列（dataStack）「機構亮點」下方新增第三張 signalCard——「展位亮點」。

## 改動
- `public/constant/content.ts`：在 `hero` 字典補上 `boothSignalLabel` / `boothSignalText`（en 與 zh-Hant 兩份）。
- `components/HomePage/Home2026.tsx`：在 institution signalCard 之後渲染第三張 `signalCard`，`DottedStar` 用唯一 id `signal-booth`。

## 文案（zh-Hant，Hana 提供）
- 標題：展位亮點
- 內文：匯聚以太坊生態指標企業與活躍社群，呈現最新技術、產品與社群成果，打造開發者、產業夥伴與社群之間的交流場域，促成更多跨域連結與合作。

## 需要 review 的地方
- **英文文案為 boba 草擬**（原文只有中文），請確認 `Booth Highlights` 標題與英文內文是否符合要對外使用的正式措辭。

用途：簽證申請所需，旅行社建議放上。