### PR TITLE
chore: remove ungated speaker-apply CTAs now that the CFP has closed

### DIFF
--- a/components/HomePage/Banner.tsx
+++ b/components/HomePage/Banner.tsx
@@ -6,7 +6,6 @@ import { month, year } from "@/public/constant/content";
 import { FLAGS } from "@/public/constant/flags";
 import {
   sideEventFormUrl,
-  speakerApplyUrl,
   sponsorApplyUrl,
   tickSiteUrl,
 } from "@/public/constant/urls";
@@ -103,10 +102,6 @@ const Banner = () => {
         <HeroCtaContainer>
           <HeroCta href={tickSiteUrl} target="_blank" rel="noreferrer">
             {t.hero.requestTicket}
-            <CtaArrow>→</CtaArrow>
-          </HeroCta>
-          <HeroCta href={speakerApplyUrl} target="_blank" rel="noreferrer">
-            {t.hero.applyToSpeak}
             <CtaArrow>→</CtaArrow>
           </HeroCta>
           <HeroCta href={sponsorApplyUrl} target="_blank" rel="noreferrer">

--- a/components/HomePage/CallToAction.tsx
+++ b/components/HomePage/CallToAction.tsx
@@ -6,7 +6,6 @@ import { FLAGS } from "@/public/constant/flags";
 import {
   sideEventApplyUrl,
   sponsorApplyUrl,
-  speakerApplyUrl,
 } from "@/public/constant/urls";
 import { openNewTab } from "@/public/utils/common";
 import Colors from "@/styles/colors";
@@ -28,10 +27,6 @@ const ActionButton = ({ url, text }: { url: string; text: string }) => (
 const ActionButtons = () => {
   const t = useT();
   const buttons = [
-    {
-      url: speakerApplyUrl,
-      text: t.callToAction.applyToSpeak,
-    },
     {
       url: sponsorApplyUrl,
       text: t.callToAction.applyToSponsor,

--- a/components/Layout/Header.tsx
+++ b/components/Layout/Header.tsx
@@ -17,7 +17,6 @@ import { FLAGS } from "@/public/constant/flags";
 import {
   discordUrl,
   sideEventApplyUrl,
-  speakerApplyUrl,
   sponsorApplyUrl,
   telegramUrl,
   tickSiteUrl,
@@ -69,7 +68,7 @@ const buildNavItems = (t: Dictionary) => [
   {
     label: t.navs.apply,
     path: "/#calltoaction",
-    disabled: !FLAGS.showApplyCTAs && !speakerApplyUrl,
+    disabled: !FLAGS.showApplyCTAs,
   },
   { label: t.navs.venue, path: "/#venue", disabled: false },
   { label: t.navs.community, path: "/community#info", disabled: false },
@@ -77,7 +76,6 @@ const buildNavItems = (t: Dictionary) => [
 ];
 
 const buildApplyDropdownItems = (t: Dictionary) => [
-  { label: t.navs.toSpeak, url: speakerApplyUrl },
   { label: t.navs.toSponsor, url: sponsorApplyUrl },
   { label: t.navs.sideEvent, url: sideEventApplyUrl },
 ];


### PR DESCRIPTION
Follow-up to the CFP close. The 2026 hero and header (`Home2026.tsx`, `Header2026.tsx`) already hide their "Apply to Speak" buttons behind `useCfpPhase`, so nothing leaks on the live site today. But three CTAs sat outside that check and could resurface an application link.

## What was removed

| File | CTA | Reachable today? |
|---|---|---|
| `components/HomePage/Banner.tsx` | Unconditional "Apply to Speak" hero button | No — file is unreferenced |
| `components/Layout/Header.tsx` | "to Speak" in the apply dropdown | No — legacy layout never renders |
| `components/HomePage/CallToAction.tsx` | "Apply to Speak" action button | **Yes, if `FLAGS.showApplyCTAs` is flipped on** |

`CallToAction.tsx` is the one that mattered — it's dynamically imported by `pages/index.tsx` and hidden only by `FLAGS.showApplyCTAs`, currently `false`. Turning that flag back on to advertise sponsorship or side events would have brought the speaker CTA back with it. It wasn't in the original brief; I included it because leaving it would defeat the point of the other two.

## Drive-by fix

`Header.tsx`'s nav-item guard read `disabled: !FLAGS.showApplyCTAs && !speakerApplyUrl`. `speakerApplyUrl` is a non-empty string constant, so `!speakerApplyUrl` was always `false` and the whole expression always `false` — the Apply nav item was never actually disabled, flag or not. Now it keys off the flag alone.

## What stayed

`speakerApplyUrl` in `urls.ts` and the `navs.toSpeak` / `callToAction.applyToSpeak` copy in both dictionaries. The constant now has exactly two consumers, both CFP-gated, and the strings will be wanted when the CFP reopens next cycle.

The legacy `Banner.tsx` and the `MainLayout`/`Header.tsx` pair are dead code in full — every page defines its own `getLayout`. Deleting them outright is a bigger cleanup with its own review surface, so I left them in place; happy to do it separately.

## Testing

`tsc --noEmit` clean, `next lint` clean, `npm test` passes (11), `npm run build` succeeds. Grepped the prerendered `index.html`: zero hits for "Apply to Speak", "to Speak", "Call for Speakers", or `apply/speaker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)