### PR TITLE
feat: update Institution Day agenda

### DIFF
--- a/components/AgendaPage2026/AgendaPage2026.module.css
+++ b/components/AgendaPage2026/AgendaPage2026.module.css
@@ -1,481 +1,511 @@
 .page {
-  /* Header2026's fixed topbar sizes off --site-nav-height, which is normally
-     set on .home-2026. This page isn't wrapped in that class, so define it here
-     or the nav-height calc collapses and content slides under the header. */
   --site-nav-height: 76px;
-  --day-accent: var(--acid);
-  --day-accent-soft: rgb(203 241 1 / 0.42);
-  position: relative;
+  --ink: #f2f5eb;
+  --muted: #aeb8c9;
+  --panel: rgb(21 29 47 / 0.86);
+  --institution-blue: #5f7cff;
+  --institution-amber: #e7af45;
+  --institution-line: rgb(235 241 255 / 0.14);
+  --institution-raised: #0e1321;
   min-height: 100svh;
-  overflow: hidden;
-  isolation: isolate;
   background:
-    radial-gradient(circle at 12% 16%, rgb(203 241 1 / 0.12), transparent 28rem),
-    radial-gradient(circle at 88% 22%, oklch(59% 0.22 266 / 0.18), transparent 30rem),
-    linear-gradient(180deg, oklch(10% 0.027 255), oklch(7% 0.018 255));
-  transition: background 0.4s ease;
+    radial-gradient(circle at 12% 4%, rgb(203 241 1 / 0.1), transparent 27rem),
+    radial-gradient(circle at 88% 12%, rgb(83 109 255 / 0.17), transparent 31rem),
+    var(--night);
 }
 
-.page[data-day="day2"] {
-  --day-accent: var(--amber);
-  --day-accent-soft: oklch(78% 0.18 70 / 0.42);
-  background:
-    radial-gradient(circle at 12% 16%, oklch(78% 0.18 70 / 0.12), transparent 28rem),
-    radial-gradient(circle at 88% 22%, oklch(59% 0.22 266 / 0.18), transparent 30rem),
-    linear-gradient(180deg, oklch(10% 0.027 255), oklch(7% 0.018 255));
+.page[data-locale="en"] {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
+    Arial, sans-serif;
+  -webkit-font-smoothing: auto;
+  text-rendering: optimizeLegibility;
+}
+
+.page[data-locale="en"] .title {
+  max-width: none;
+  font-family: "Menlo", ui-monospace, monospace;
+  font-size: clamp(34px, 7vw, 84px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  white-space: nowrap;
+}
+
+.page[data-locale="en"] .agendaSection,
+.page[data-locale="en"] .speakers {
+  font-family: "Menlo", ui-monospace, monospace;
 }
 
 .main {
   position: relative;
+  z-index: 1;
   min-height: 100svh;
-  padding: calc(var(--nav-h) + 64px) clamp(20px, 6vw, 88px) 112px;
+  padding: calc(var(--nav-h) + 54px) clamp(20px, 4vw, 56px) 96px;
   scroll-margin-top: var(--nav-h);
 }
 
 .main::before {
   position: absolute;
   inset: 0;
-  z-index: -2;
+  z-index: -1;
   content: "";
-  opacity: 0.22;
+  opacity: 0.18;
   background-image:
-    linear-gradient(rgb(203 241 1 / 0.16) 1px, transparent 1px),
-    linear-gradient(90deg, rgb(203 241 1 / 0.16) 1px, transparent 1px);
+    linear-gradient(rgb(203 241 1 / 0.18) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(203 241 1 / 0.18) 1px, transparent 1px);
   background-position: center;
   background-size: 46px 46px;
-  mask-image: radial-gradient(120% 90% at 50% 20%, black 26%, transparent 82%);
+  mask-image: radial-gradient(100% 70% at 50% 0%, black 12%, transparent 75%);
 }
 
 .shell {
-  width: min(100%, 1080px);
+  width: min(100%, 1180px);
   margin: 0 auto;
 }
 
-/* ---------- Intro ---------- */
-.intro {
-  max-width: 860px;
+.hero {
+  display: block;
 }
 
-.eyebrow {
-  margin: 0 0 18px;
-  color: var(--day-accent);
-  font-size: clamp(13px, 1.3vw, 16px);
-  font-weight: 600;
-  letter-spacing: 0.22em;
-  transition: color 0.3s ease;
+.eyebrow,
+.sectionKicker {
+  margin: 0;
+  color: var(--acid);
+  font-family: "Menlo", ui-monospace, monospace;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
 }
 
 .title {
-  margin: 0;
+  max-width: 760px;
+  margin: 16px 0 0;
   color: var(--ink);
-  font-size: clamp(56px, 8vw, 104px);
+  font-size: clamp(66px, 7.2vw, 104px);
   font-weight: 700;
-  letter-spacing: -0.02em;
-  line-height: 0.88;
+  letter-spacing: -0.05em;
+  line-height: 0.92;
   text-shadow:
     0 2px 3px oklch(0% 0 0 / 0.55),
-    0 14px 34px oklch(0% 0 0 / 0.62);
+    0 18px 42px oklch(0% 0 0 / 0.65);
 }
 
-.title span {
-  color: var(--day-accent);
-  text-shadow: 0 0 34px var(--day-accent-soft);
-  transition: color 0.3s ease, text-shadow 0.3s ease;
+.eventDate {
+  display: block;
+  margin-top: 20px;
+  color: var(--institution-amber);
+  font-family: "Menlo", ui-monospace, monospace;
+  font-size: 16px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
 }
 
-.lede {
-  max-width: 680px;
-  margin: 26px 0 0;
-  color: var(--muted);
-  font-family: "Inter", ui-sans-serif, sans-serif;
-  font-size: clamp(15px, 1.5vw, 18px);
-  line-height: 1.7;
+.agendaSection {
+  margin-top: 64px;
 }
 
-.lede b {
-  color: var(--ink);
-  font-weight: 600;
+.sectionHeading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
 }
 
-/* ---------- Day tabs ---------- */
-.dayTabs {
+.agendaTable {
+  display: block;
+  width: 100%;
+  border: 1px solid var(--institution-line);
+  border-radius: 5px 24px 5px 24px;
+  background: rgb(8 13 23 / 0.74);
+  box-shadow: var(--shadow);
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.agendaHead,
+.agendaBody {
+  display: block;
+}
+
+.agendaHead {
   position: sticky;
   top: var(--nav-h);
-  z-index: 5;
-  display: flex;
-  gap: 12px;
-  margin: clamp(40px, 6vw, 64px) 0 8px;
-  padding: 14px 0;
-  background: linear-gradient(180deg, var(--night) 62%, transparent);
+  z-index: 20;
+  border-bottom: 1px solid var(--institution-line);
+  border-radius: 5px 24px 0 0;
+  background: #101727;
+  box-shadow: 0 10px 24px rgb(0 0 0 / 0.24);
 }
 
-.dayTab {
-  flex: 1;
-  padding: 16px 18px;
-  border: 1px solid var(--panel-line);
-  border-radius: 4px 16px 4px 16px;
-  background: oklch(14% 0.025 255 / 0.6);
-  color: var(--muted);
-  font-family: "Inter", ui-sans-serif, sans-serif;
+.agendaHeadRow,
+.agendaRow {
+  display: grid;
+  grid-template-columns: 164px minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.headCell {
+  display: flex;
+  min-height: 80px;
+  align-items: center;
+  padding: 17px 20px;
+  border-left: 1px solid var(--institution-line);
+  color: var(--ink);
+  font-size: 20px;
   text-align: left;
-  cursor: pointer;
-  transition: all 0.18s ease;
-  backdrop-filter: blur(12px);
 }
 
-.dayTab:hover {
-  color: var(--ink);
-  border-color: oklch(96% 0.018 126 / 0.32);
-  transform: translateY(-2px);
+.headCell:first-child {
+  align-items: flex-end;
+  border-left: 0;
+  border-radius: 5px 0 0;
+  color: var(--muted);
+  font-family: "Menlo", ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.11em;
 }
 
-.dayTabDate {
+.headCell:last-child {
+  border-radius: 0 24px 0 0;
+}
+
+.agendaRow {
+  border-bottom: 1px solid var(--institution-line);
+}
+
+.agendaRow:last-child {
+  border-bottom: 0;
+}
+
+.time {
   display: block;
-  font-family: "Menlo", monospace;
-  font-size: clamp(18px, 2.4vw, 24px);
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  padding: 22px 18px;
+  color: var(--muted);
+  font-family: "Menlo", ui-monospace, monospace;
+  font-weight: 400;
+  text-align: left;
 }
 
-.dayTabName {
+.time strong {
   display: block;
-  margin-top: 4px;
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
-.dayTab[aria-selected="true"] {
-  color: var(--night);
-  background: var(--acid);
-  border-color: var(--acid);
-}
-
-.dayTab[aria-selected="true"]:nth-child(2) {
-  background: var(--amber);
-  border-color: var(--amber);
-}
-
-.dayTab:focus-visible {
-  outline: 2px solid var(--day-accent);
-  outline-offset: 3px;
-}
-
-/* ---------- Panels ---------- */
-.panel {
-  animation: fade 0.32s ease;
-}
-
-@keyframes fade {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.bandCard {
-  position: relative;
-  overflow: hidden;
-  margin-top: 20px;
-  padding: clamp(24px, 3.4vw, 34px);
-  border: 1px solid var(--panel-line);
-  border-left: 4px solid var(--acid);
-  border-radius: 4px 20px 4px 20px;
-  background:
-    linear-gradient(135deg, rgb(203 241 1 / 0.07), transparent 46%, rgb(57 82 255 / 0.08)),
-    oklch(12% 0.027 255 / 0.82);
-  backdrop-filter: blur(16px);
-}
-
-.bandCardAlt {
-  border-left-color: var(--amber);
-  background:
-    linear-gradient(135deg, oklch(78% 0.18 70 / 0.08), transparent 46%, rgb(57 82 255 / 0.08)),
-    oklch(12% 0.027 255 / 0.82);
-}
-
-.bandCard::after {
-  position: absolute;
-  inset: 0 0 auto;
-  height: 3px;
-  content: "";
-  background: linear-gradient(90deg, var(--acid), var(--blue), var(--amber));
-}
-
-.bandTag {
-  font-family: "Menlo", monospace;
-  font-size: 11px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.bandName {
-  margin: 10px 0 8px;
   color: var(--ink);
-  font-size: clamp(24px, 3vw, 34px);
-  font-weight: 700;
-  letter-spacing: -0.01em;
+  font-size: 16px;
+  white-space: nowrap;
 }
 
-.bandSub {
-  max-width: 720px;
-  margin: 0;
-  color: var(--muted);
-  font-family: "Inter", ui-sans-serif, sans-serif;
-  font-size: clamp(14px, 1.4vw, 16px);
-  line-height: 1.65;
-}
-
-.sectionLabel {
-  margin: 40px 0 0;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--panel-line);
-  color: var(--day-accent);
-  font-family: "Menlo", monospace;
-  font-size: 13px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-}
-
-/* ---------- Pillars (Day 1) ---------- */
-.pillars {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(248px, 1fr));
-  gap: 16px;
-  margin-top: 24px;
-}
-
-.pillar {
-  position: relative;
-  overflow: hidden;
-  padding: 24px 22px 26px;
-  border: 1px solid var(--panel-line);
-  border-top: 2px solid var(--acid);
-  border-radius: 4px 14px 4px 14px;
-  background:
-    linear-gradient(135deg, rgb(203 241 1 / 0.05), transparent 60%),
-    oklch(13% 0.025 255 / 0.7);
-  transition: transform 0.18s ease, background 0.18s ease;
-}
-
-.pillar:hover {
-  transform: translateY(-3px);
-  background:
-    linear-gradient(135deg, rgb(203 241 1 / 0.1), transparent 60%),
-    oklch(15% 0.025 255 / 0.8);
-}
-
-.pillarNum {
-  font-family: "Menlo", monospace;
-  font-size: 12px;
-  letter-spacing: 0.14em;
-  color: oklch(78% 0.16 122);
-}
-
-.pillarTitle {
-  margin: 10px 0 0;
-  color: var(--ink);
-  font-size: 19px;
-  font-weight: 700;
-  line-height: 1.2;
-  letter-spacing: -0.01em;
-}
-
-.pillarDesc {
-  margin: 12px 0 0;
-  color: var(--muted);
-  font-family: "Inter", ui-sans-serif, sans-serif;
-  font-size: 13.5px;
-  line-height: 1.6;
-}
-
-/* ---------- Sessions & slots (Day 2) ---------- */
 .session {
-  margin-top: 44px;
+  position: relative;
+  height: 100%;
+  min-width: 0;
+  padding: 20px;
+  border-left: 1px solid var(--institution-line);
+  background: linear-gradient(135deg, rgb(203 241 1 / 0.055), transparent 55%);
 }
 
-.sessionHead {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 16px;
-  padding-bottom: 14px;
-  border-bottom: 2px solid var(--amber);
-  margin-bottom: 4px;
+.session::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--acid);
+  content: "";
+  opacity: 0.85;
 }
 
-.sessionHead h2 {
-  margin: 0;
-  color: var(--ink);
-  font-size: clamp(18px, 2.2vw, 23px);
-  font-weight: 700;
-  letter-spacing: -0.01em;
+.forumSession {
+  background: linear-gradient(135deg, rgb(95 124 255 / 0.1), transparent 55%);
 }
 
-.sessionRange {
-  font-family: "Menlo", monospace;
-  font-size: 14px;
-  color: var(--amber);
-  white-space: nowrap;
+.forumSession::before {
+  background: var(--institution-blue);
 }
 
-.slot {
-  display: grid;
-  grid-template-columns: 96px 1fr;
-  gap: 20px;
-  padding: 22px 4px;
-  border-bottom: 1px solid var(--panel-line);
-  transition: background 0.15s ease;
+.sharedSession {
+  background:
+    linear-gradient(110deg, rgb(231 175 69 / 0.12), transparent 46%),
+    var(--panel);
 }
 
-.slot:hover {
-  background: oklch(78% 0.18 70 / 0.04);
+.sharedSession::before {
+  background: var(--institution-amber);
 }
 
-.slotTime {
-  font-family: "Menlo", monospace;
-  font-size: 14px;
-  color: var(--ink);
-  padding-top: 2px;
-  white-space: nowrap;
-}
-
-.slotDur {
-  display: block;
-  margin-top: 4px;
-  font-size: 11px;
-  color: var(--muted);
-}
-
-.slotTitle {
-  margin: 0 0 8px;
-  color: var(--ink);
-  font-size: clamp(16px, 1.7vw, 18px);
-  font-weight: 600;
-  line-height: 1.35;
-}
-
-.slotDesc {
-  margin: 0 0 12px;
-  color: var(--muted);
-  font-family: "Inter", ui-sans-serif, sans-serif;
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.slotFooter {
+.sessionMeta {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  gap: 10px 14px;
+  gap: 6px;
+  margin-bottom: 12px;
 }
 
-.slotPanel {
-  border-left: 2px solid var(--amber);
-  padding-left: 16px;
-  background: oklch(78% 0.18 70 / 0.05);
-}
-
-.slotPanel:hover {
-  background: oklch(78% 0.18 70 / 0.08);
-}
-
-.fmt {
-  display: inline-block;
-  padding: 3px 10px;
+.sessionMeta span {
+  display: inline-flex;
+  padding: 6px 8px;
+  border: 1px solid rgb(203 241 1 / 0.35);
   border-radius: 999px;
-  font-family: "Menlo", monospace;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
+  color: var(--acid);
+  background: rgb(9 14 25 / 0.72);
+  font-family: "Menlo", ui-monospace, monospace;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.fmtTalk {
-  background: oklch(78% 0.18 70 / 0.16);
-  color: var(--amber);
+.forumSession .sessionMeta span {
+  color: #aebbff;
+  border-color: rgb(95 124 255 / 0.4);
 }
 
-.fmtPanel {
-  background: var(--amber);
-  color: var(--night);
+.session h3 {
+  max-width: 520px;
+  margin: 0;
+  color: var(--ink);
+  font-size: 20px;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
 }
 
-.tag {
-  display: inline-block;
-  padding: 3px 10px;
-  border: 1px solid var(--blue);
-  border-radius: 999px;
-  color: oklch(72% 0.16 266);
-  font-family: "Menlo", monospace;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-}
-
-/* ---------- Break ---------- */
-.break {
-  display: grid;
-  grid-template-columns: 96px 1fr;
-  gap: 20px;
-  padding: 16px 4px;
-  border-bottom: 1px solid var(--panel-line);
-}
-
-.breakLabel {
-  align-self: center;
-  color: var(--amber);
-  font-family: "Menlo", monospace;
+.speakers {
+  margin: 12px 0 0;
+  color: var(--ink);
+  font-family: "Inter", "PingFang TC", sans-serif;
   font-size: 13px;
-  letter-spacing: 0.12em;
+  line-height: 1.55;
+}
+
+.organization {
+  color: var(--muted);
+}
+
+.speakerRole {
+  color: var(--institution-amber);
+}
+
+.pendingSpeaker {
+  color: var(--muted);
+}
+
+.sessionCell {
+  min-width: 0;
+  padding: 0;
+}
+
+.wideCell {
+  grid-column: 2 / 4;
+}
+
+.transitionRow {
+  background: rgb(231 175 69 / 0.035);
+}
+
+.transitionRow .time {
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.transitionRow .time strong {
+  color: var(--institution-amber);
+  font-size: 13px;
+}
+
+.transition {
+  grid-column: 2 / 4;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 10px 20px;
+  border-left: 1px solid var(--institution-line);
+  color: #f3cf87;
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgb(231 175 69 / 0.05) 0 7px,
+      transparent 7px 14px
+    ),
+    var(--institution-raised);
+  font-family: "Menlo", ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
-/* ---------- Note ---------- */
-.note {
-  margin-top: 40px;
-  padding: 18px 22px;
-  border: 1px dashed var(--panel-line);
-  border-radius: 4px 12px 4px 12px;
-  color: var(--muted);
-  font-family: "Inter", ui-sans-serif, sans-serif;
+.transition::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--institution-amber);
+  content: "";
+}
+
+.transitionIcon {
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--institution-line);
+  border-radius: 50%;
   font-size: 14px;
-  line-height: 1.65;
+  line-height: 1;
 }
 
-.note b {
-  color: var(--day-accent);
-  font-weight: 600;
+.intermission {
+  grid-column: 2 / 4;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px;
+  border-left: 1px solid var(--institution-line);
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgb(255 255 255 / 0.025) 0 8px,
+      transparent 8px 16px
+    ),
+    var(--institution-raised);
 }
 
-@media (max-width: 980px) {
-  .page {
-    --site-nav-height: 70px;
+.intermission::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--muted);
+  content: "";
+  opacity: 0.35;
+}
+
+.intermissionCopy {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.intermissionIcon {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--institution-line);
+  border-radius: 50%;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.intermission h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 18px;
+}
+
+@media (max-width: 900px) {
+  .agendaHead {
+    display: none;
+  }
+
+  .agendaRow {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .time {
+    position: sticky;
+    top: var(--nav-h);
+    z-index: 12;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--institution-line);
+    background: #101727;
+    box-shadow: 0 8px 18px rgb(0 0 0 / 0.22);
+  }
+
+  .sessionCell,
+  .wideCell,
+  .transition,
+  .intermission {
+    grid-column: 1;
+    border-left: 0;
+  }
+
+  .sessionCell::before {
+    display: block;
+    padding: 9px 16px;
+    border-bottom: 1px solid var(--institution-line);
+    color: var(--muted);
+    background: rgb(16 23 39 / 0.84);
+    content: attr(data-stage-label);
+    font-family: "Menlo", ui-monospace, monospace;
+    font-size: 10px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+  }
+
+  .sessionCell + .sessionCell {
+    border-top: 1px solid var(--institution-line);
+  }
+
+  .session {
+    border-left: 0;
   }
 }
 
-@media (max-width: 760px) {
+@media (max-width: 640px) {
   .main {
-    padding: calc(var(--nav-h) + 44px) 18px 84px;
+    padding: calc(var(--nav-h) + 34px) 16px 72px;
   }
 
-  .slot,
-  .break {
-    grid-template-columns: 66px 1fr;
-    gap: 14px;
+  .title {
+    font-size: clamp(44px, 16vw, 64px);
   }
 
-  .sessionHead {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-  }
 }
 
-@media (max-width: 420px) {
-  .title {
-    font-size: clamp(48px, 16vw, 66px);
+@media print {
+  .page {
+    color: #111;
+    background: #fff;
   }
 
-  .dayTab {
-    padding: 13px 14px;
+  .main {
+    padding: 0;
+  }
+
+  .main::before {
+    display: none;
+  }
+
+  .agendaTable,
+  .session,
+  .forumSession,
+  .sharedSession,
+  .intermission {
+    color: #111;
+    background: #fff;
+    box-shadow: none;
+  }
+
+  .agendaHead {
+    color: #111;
+    background: #f2f2f2;
+  }
+
+  .time,
+  .time strong,
+  .speakers,
+  .organization {
+    color: #333;
   }
 }

--- a/components/AgendaPage2026/index.tsx
+++ b/components/AgendaPage2026/index.tsx
@@ -2,378 +2,487 @@ import Header2026 from "@/components/Layout/Header2026";
 import type { CfpPhase } from "@/components/hooks/useCfpPhase";
 import { useLanguage } from "@/contexts/LanguageContext";
 import type { Locale } from "@/public/constant/content";
-import { type ReactNode, useState } from "react";
+import Head from "next/head";
 
 import homeStyles from "@/components/HomePage/Home2026.module.css";
 import styles from "./AgendaPage2026.module.css";
 
-type DayId = "day1" | "day2";
+type AgendaText = Record<Locale, string>;
 
-type Pillar = {
-  n: string;
-  title: string;
-  desc: string;
-};
+const text = (en: string, zhHant: string): AgendaText => ({
+  en,
+  "zh-Hant": zhHant,
+});
 
-type Slot = {
-  time: string;
-  dur: string;
-  title: string;
-  desc: string;
-  format: "talk" | "panel";
-  tag: string;
+const localize = (value: AgendaText | string, locale: Locale) =>
+  typeof value === "string" ? value : value[locale];
+
+type Speaker = {
+  name?: string;
+  alias?: string;
+  jobTitle?: AgendaText;
+  organization?: AgendaText;
+  role?: AgendaText;
+  status?: "confirmed" | "pending";
 };
 
 type Session = {
-  heading: string;
-  range: string;
-  slots: Slot[];
+  format: AgendaText;
+  title: AgendaText;
+  speakers?: Speaker[];
 };
 
-type AgendaCopy = {
-  eyebrow: string;
-  title: string;
-  lede: ReactNode;
-  fmtTalk: string;
-  fmtPanel: string;
-  days: { id: DayId; date: string; name: string }[];
-  day1: {
-    bandTag: string;
-    bandName: string;
-    bandSub: string;
+type AgendaRow = {
+  time: AgendaText | string;
+  dateTime: string;
+  main?: Session;
+  forum?: Session;
+  shared?: Session;
+  intermission?: {
+    icon: string;
+    title: AgendaText;
+  };
+  transition?: AgendaText;
+};
+
+const UI_COPY: Record<
+  Locale,
+  {
+    metaTitle: string;
+    metaDescription: string;
+    eyebrow: string;
+    title: string;
+    eventDate: string;
+    scheduleLabel: string;
     sectionLabel: string;
-    pillars: Pillar[];
-    note: ReactNode;
-  };
-  day2: {
-    bandTag: string;
-    bandName: string;
-    bandSub: string;
-    breakLabel: string;
-    sessions: Session[];
-    note: ReactNode;
-  };
+    caption: string;
+    timeHeader: string;
+    mainStage: string;
+    forumStage: string;
+    sharedStage: string;
+    pendingSpeaker: string;
+    moreSpeakersPending: string;
+    detailSeparator: string;
+    openParen: string;
+    closeParen: string;
+    labelSeparator: string;
+  }
+> = {
+  en: {
+    metaTitle: "ETHTaipei 2026 | Institution Day",
+    metaDescription: "ETHTaipei 2026 Institution Day schedule",
+    eyebrow: "ETHTAIPEI 2026",
+    title: "Institution Day",
+    eventDate: "September 14, 2026",
+    scheduleLabel: "Schedule",
+    sectionLabel: "Institution Day schedule",
+    caption: "ETHTaipei 2026 Institution Day schedule",
+    timeHeader: "Time",
+    mainStage: "Main Hall (Building M)",
+    forumStage: "Forum Hall (Building A2)",
+    sharedStage: "Joint session",
+    pendingSpeaker: "Speaker to be announced",
+    moreSpeakersPending: "More speakers to be announced",
+    detailSeparator: ", ",
+    openParen: " (",
+    closeParen: ")",
+    labelSeparator: " | ",
+  },
+  "zh-Hant": {
+    metaTitle: "ETHTaipei 2026｜機構日",
+    metaDescription: "ETHTaipei 2026 機構日議程",
+    eyebrow: "ETHTAIPEI 2026",
+    title: "機構日",
+    eventDate: "2026 年 9 月 14 日",
+    scheduleLabel: "當日議程",
+    sectionLabel: "機構日議程",
+    caption: "ETHTaipei 2026 機構日議程",
+    timeHeader: "時間",
+    mainStage: "主舞台（M 棟）",
+    forumStage: "論壇舞台（A2 棟）",
+    sharedStage: "共同議程",
+    pendingSpeaker: "講者即將公布",
+    moreSpeakersPending: "更多講者即將公布",
+    detailSeparator: "・",
+    openParen: "（",
+    closeParen: "）",
+    labelSeparator: "｜",
+  },
 };
 
-const MORNING_RANGE = "10:00 – 12:00";
-
-const COPY: Record<Locale, AgendaCopy> = {
-  en: {
-    eyebrow: "ETHTAIPEI 2026 · AGENDA",
-    title: "Agenda",
-    lede: (
-      <>
-        Two days at ETHTaipei 2026: <b>Sep 13 — Cryptonative Day</b> belongs to
-        the Ethereum builder community; <b>Sep 14 — Institution Day</b> is built
-        for banks and financial institutions. This is a draft — topics and timing
-        may change.
-      </>
-    ),
-    fmtTalk: "Talk",
-    fmtPanel: "Panel",
-    days: [
-      { id: "day1", date: "SEP 13", name: "Cryptonative Day" },
-      { id: "day2", date: "SEP 14", name: "Institution Day" },
-    ],
-    day1: {
-      bandTag: "Day 01 · Sep 13 · Main Stage",
-      bandName: "Cryptonative Day",
-      bandSub:
-        "A day for the Ethereum builder community — from core protocol to consumer apps. Full schedule and speaker lineup in progress.",
-      sectionLabel: "What to Expect",
-      pillars: [
+const AGENDA_ROWS: AgendaRow[] = [
+  {
+    time: "10:00–10:30",
+    dateTime: "2026-09-14T10:00:00+08:00",
+    shared: {
+      format: text("Keynote", "主題演講"),
+      title: text("Taiwan's Crypto Adoption Vision", "台灣加密產業的下一步"),
+      speakers: [
         {
-          n: "01",
-          title: "Protocol & Core Dev",
-          desc: "Consensus, execution- and consensus-layer clients, EIPs, and the road to the next hard fork.",
-        },
-        {
-          n: "02",
-          title: "L2s & Scaling",
-          desc: "Rollups, shared sequencing, interop, data availability, and seamless cross-L2 UX.",
-        },
-        {
-          n: "03",
-          title: "ZK & Privacy",
-          desc: "Proving systems, zkEVMs, coprocessors, and privacy-preserving applications.",
-        },
-        {
-          n: "04",
-          title: "Wallets & Account Abstraction",
-          desc: "Smart accounts, ERC-4337 / 7702, passkeys, and gasless UX.",
-        },
-        {
-          n: "05",
-          title: "DeFi",
-          desc: "AMMs, lending, stablecoins, intents, and on-chain risk management.",
-        },
-        {
-          n: "06",
-          title: "Consumer & Social",
-          desc: "On-chain social, gaming, payments, and apps built for everyday users.",
-        },
-        {
-          n: "07",
-          title: "Security",
-          desc: "Auditing, formal verification, MEV, and keeping users and protocols safe.",
-        },
-        {
-          n: "08",
-          title: "Infra & Tooling",
-          desc: "RPC, indexing, dev frameworks, and oracles — the plumbing builders rely on.",
+          name: "Jamie Lin",
+          organization: text("Taiwan Mobile", "台灣大哥大"),
         },
       ],
-      note: (
-        <>
-          <b>Schedule in progress.</b> The full timetable, talk titles, and
-          speakers will be announced once the lineup is confirmed. Above are the
-          themes this day is expected to cover.
-        </>
-      ),
-    },
-    day2: {
-      bandTag: "Day 02 · Sep 14 · Main Stage",
-      bandName: "Institution Day",
-      bandSub:
-        "A one-day track built for banks and financial institutions — the morning on institutional-grade custody and wallet architecture, the afternoon on RWA and tokenized-equity practice and chain selection. Single track · Main Stage.",
-      breakLabel: "Lunch & Networking",
-      sessions: [
-        {
-          heading: "Morning · Custody / Wallet",
-          range: MORNING_RANGE,
-          slots: [
-            {
-              time: "10:00",
-              dur: "30 min",
-              title:
-                "From Smart Accounts to Compliant Accounts: The Future of Institutional Wallets",
-              desc: "How the wallet stack is evolving — authentication, roles and permissions, transaction policy, real-time risk checks, audit trails, and compliance modules — into the next generation of institutional wallets.",
-              format: "talk",
-              tag: "Custody / Wallets",
-            },
-            {
-              time: "10:30",
-              dur: "30 min",
-              title: "Security in Digital Assets & Smart Contracts",
-              desc: "Web3 security across the stack — from safeguarding assets and hardening smart contracts to securing surrounding infrastructure and protecting staff from social engineering.",
-              format: "talk",
-              tag: "Security",
-            },
-            {
-              time: "11:00",
-              dur: "60 min",
-              title:
-                "Panel — Stablecoin Types & Risk Management: USDC / USDT / OUSD / DAI / USDe",
-              desc: "Perspectives on the major stablecoins in the market, their stability mechanisms, and how to classify their risks.",
-              format: "panel",
-              tag: "Stablecoins",
-            },
-          ],
-        },
-        {
-          heading: "Afternoon · RWA / Tokenized Stocks",
-          range: "13:00 – 16:00",
-          slots: [
-            {
-              time: "13:00",
-              dur: "30 min",
-              title:
-                "How Are Tokenized US Stocks Issued? Three Models, from Ondo to xStocks",
-              desc: "Using Ondo Global Markets as the anchor case — compared with Backed Finance (xStocks) and Dinari — we break down three key differences behind tokenized US equities: collateral & custody architecture, regulatory jurisdiction, and investor eligibility & liquidity design.",
-              format: "talk",
-              tag: "RWA / Stocks",
-            },
-            {
-              time: "13:30",
-              dur: "30 min",
-              title:
-                "Positioning for the Trillion-Dollar “Machine Finance” Market of Autonomous AI Agents",
-              desc: "Starting from x402 (backed by the Linux Foundation and others), how autonomous AI agents pay and transact on-chain — and what this “machine finance” market means for financial institutions.",
-              format: "talk",
-              tag: "AI / Machine Finance",
-            },
-            {
-              time: "14:00",
-              dur: "60 min",
-              title: "Panel — Tokenization Progress at Traditional Finance Giants",
-              desc: "Representatives from traditional financial infrastructure — NYSE, Nasdaq, SWIFT and others — share where they are on tokenization, the regulatory and technical challenges they face, and their outlook for the next 3–5 years.",
-              format: "panel",
-              tag: "Tokenization",
-            },
-            {
-              time: "15:00",
-              dur: "60 min",
-              title:
-                "Panel — Private vs. Public Chains: The Real Decision Axes for Institutions",
-              desc: "Breaking the debate into the axes that actually matter — data privacy, regulatory control, finality guarantees, liquidity access, and vendor lock-in — rather than a vague notion of “security.” Where Besu / Canton / Prividium / public chains each stand.",
-              format: "panel",
-              tag: "Chain Selection",
-            },
-          ],
-        },
-      ],
-      note: (
-        <>
-          <b>Tentative schedule.</b> Topics and timing may change; the speaker
-          lineup will be announced once confirmed.
-        </>
-      ),
     },
   },
-
-  "zh-Hant": {
-    eyebrow: "ETHTAIPEI 2026 · 議程",
-    title: "議程",
-    lede: (
-      <>
-        ETHTaipei 2026 的兩天：<b>9/13 Cryptonative Day</b> 屬於以太坊開發者社群；
-        <b>9/14 Institution Day</b> 為銀行與金融機構打造。以下為草稿，講題與時間可能調整。
-      </>
-    ),
-    fmtTalk: "演講",
-    fmtPanel: "座談",
-    days: [
-      { id: "day1", date: "SEP 13", name: "開發者日" },
-      { id: "day2", date: "SEP 14", name: "機構日" },
-    ],
-    day1: {
-      bandTag: "Day 01 · 9/13 · 主舞台",
-      bandName: "Cryptonative Day · 開發者的一天",
-      bandSub:
-        "屬於以太坊開發者社群的一天——從核心協議到消費級應用。完整時間表與講者陣容建構中，陸續公布。",
-      sectionLabel: "主題方向",
-      pillars: [
-        {
-          n: "01",
-          title: "協議與核心開發",
-          desc: "共識、執行層與共識層客戶端、EIP，以及邁向下一個硬分叉的路線圖。",
-        },
-        {
-          n: "02",
-          title: "L2 與擴容",
-          desc: "Rollups、共享排序、跨鏈互通、資料可用性，以及無縫跨 L2 的使用體驗。",
-        },
-        {
-          n: "03",
-          title: "零知識證明與隱私",
-          desc: "證明系統、zkEVM、coprocessor，以及保護隱私的鏈上應用。",
-        },
-        {
-          n: "04",
-          title: "錢包與帳戶抽象",
-          desc: "智能帳戶、ERC-4337 / 7702、passkey，以及無 gas 的使用體驗。",
-        },
-        {
-          n: "05",
-          title: "去中心化金融 DeFi",
-          desc: "AMM、借貸、穩定幣、intent 交易，以及鏈上風險管理。",
-        },
-        {
-          n: "06",
-          title: "消費級與社交應用",
-          desc: "鏈上社交、遊戲、支付，以及為日常用戶打造的應用。",
-        },
-        {
-          n: "07",
-          title: "資安",
-          desc: "稽核、形式化驗證、MEV，以及如何守護用戶與協議的安全。",
-        },
-        {
-          n: "08",
-          title: "基礎設施與工具",
-          desc: "RPC、索引、開發框架、預言機——開發者仰賴的底層管線。",
-        },
-      ],
-      note: (
-        <>
-          <b>議程建構中。</b> 完整時間表、講題與講者將於陣容確認後公布。以上為這一天預計涵蓋的主題方向。
-        </>
+  {
+    time: "10:30–10:35",
+    dateTime: "2026-09-14T10:30:00+08:00",
+    transition: text("Break", "休息時間"),
+  },
+  {
+    time: "10:35–11:05",
+    dateTime: "2026-09-14T10:35:00+08:00",
+    main: {
+      format: text("Talk", "專題演講"),
+      title: text(
+        "Stablecoin Risk Classification and Accounting Recognition",
+        "穩定幣有哪些風險？會計上怎麼認列？",
       ),
+      speakers: [{ name: "陳念平", organization: text("PwC", "PwC") }],
     },
-    day2: {
-      bandTag: "Day 02 · 9/14 · 主舞台",
-      bandName: "Institution Day · 機構日",
-      bandSub:
-        "為金融機構與從業者打造的一日議程——上半天聚焦機構級的保管與錢包架構，下半天走進 RWA 與美股代幣化的實務與選型。單軌 · 主舞台。",
-      breakLabel: "午餐 · 自由交流 Lunch & Networking",
-      sessions: [
-        {
-          heading: "上半天 · 保管與錢包 Custody / Wallet",
-          range: MORNING_RANGE,
-          slots: [
-            {
-              time: "10:00",
-              dur: "30 min",
-              title:
-                "From Smart Accounts to Compliant Accounts：下一代機構錢包",
-              desc: "從錢包的技術演進出發，探討身份驗證、角色與權限、交易政策、即時風險檢查、稽核軌跡與合規模組，如何共同構成下一代機構錢包。",
-              format: "talk",
-              tag: "保管 / 錢包",
-            },
-            {
-              time: "10:30",
-              dur: "30 min",
-              title: "虛擬資產與智能合約之資安議題",
-              desc: "Web3 相關的資安議題，從如何保管資產、確保智能合約安全、周邊伺服器之安全性，到保護職員遭受社交工程。",
-              format: "talk",
-              tag: "資安",
-            },
-            {
-              time: "11:00",
-              dur: "60 min",
-              title: "座談 — 穩定幣種類與風險管理：USDC / USDT / OUSD / DAI / USDe",
-              desc: "分享針對市面上主要穩定幣及其穩定機制、風險分類的看法。",
-              format: "panel",
-              tag: "穩定幣",
-            },
-          ],
-        },
-        {
-          heading: "下半天 · RWA / 美股代幣",
-          range: "13:00 – 16:00",
-          slots: [
-            {
-              time: "13:00",
-              dur: "30 min",
-              title: "美股代幣化怎麼發？從 Ondo 到 xStocks 的三種模式拆解",
-              desc: "以 Ondo Global Markets 為核心案例，對照 Backed Finance（xStocks）、Dinari 等主流發行方，拆解美股代幣化背後三個關鍵差異：擔保與託管架構、監管司法管轄、以及投資人資格與流動性設計。",
-              format: "talk",
-              tag: "RWA / 美股",
-            },
-            {
-              time: "13:30",
-              dur: "30 min",
-              title: "佈局自主 AI 代理的兆級美元「機器金融」新市場",
-              desc: "從 x402（由 Linux Foundation 等支持）出發，談自主 AI 代理如何在鏈上支付與交易，以及這個「機器金融」市場對金融機構的意義與機會。",
-              format: "talk",
-              tag: "AI / 機器金融",
-            },
-            {
-              time: "14:00",
-              dur: "60 min",
-              title: "座談 — 傳統金融巨頭的代幣化進程",
-              desc: "邀請 NYSE、Nasdaq、SWIFT 等傳統金融基礎設施代表，分享各自在代幣化上的布局進度、遇到的監理與技術挑戰，以及對未來 3–5 年的展望。",
-              format: "panel",
-              tag: "代幣化",
-            },
-            {
-              time: "15:00",
-              dur: "60 min",
-              title: "座談 — 私有鏈 vs. 公有鏈：機構選鏈的關鍵決策軸",
-              desc: "把爭論拆成幾個真正的決策軸——資料隱私、監理可控性、最終性保證、流動性可及性、廠商鎖定——而不是籠統的「安全」。點名 Besu / Canton / Prividium / 公鏈各自站在哪一軸。",
-              format: "panel",
-              tag: "選鏈",
-            },
-          ],
-        },
-      ],
-      note: (
-        <>
-          <b>暫定議程。</b> 講題與時間可能調整，講者陣容確認後公布。
-        </>
+    forum: {
+      format: text("Talk", "專題演講"),
+      title: text(
+        "What Ethereum Must Build for Global Finance",
+        "以太坊要如何支撐全球金融？",
       ),
+      speakers: [
+        { name: "Changwu", organization: text("imToken", "imToken") },
+      ],
     },
   },
+  {
+    time: "11:05–11:10",
+    dateTime: "2026-09-14T11:05:00+08:00",
+    transition: text("Break", "休息時間"),
+  },
+  {
+    time: "11:10–11:55",
+    dateTime: "2026-09-14T11:10:00+08:00",
+    main: {
+      format: text("Fireside Chat", "爐邊對談"),
+      title: text("The Future of Stablecoins", "穩定幣接下來會怎麼發展？"),
+      speakers: [
+        {
+          name: "温宏駿",
+          organization: text("Hayek Technology", "海耶克科技"),
+        },
+        { name: "Wayne", organization: text("XREX", "XREX") },
+      ],
+    },
+    forum: {
+      format: text("Introduction + Panel", "主題介紹＋座談"),
+      title: text(
+        "Programmable Compliance: Bringing Institutional Policy Onchain",
+        "可程式化合規：如何把機構政策帶上鏈？",
+      ),
+      speakers: [
+        { name: "Taka" },
+        { name: "Changwu", organization: text("imToken", "imToken") },
+        { name: "Jason Kuo", organization: text("Zodia", "Zodia") },
+      ],
+    },
+  },
+  {
+    time: "11:55–13:30",
+    dateTime: "2026-09-14T11:55:00+08:00",
+    intermission: {
+      icon: "🍽️",
+      title: text("Lunch", "午餐時間"),
+    },
+  },
+  {
+    time: "13:30–14:00",
+    dateTime: "2026-09-14T13:30:00+08:00",
+    main: {
+      format: text("Talk", "專題演講"),
+      title: text(
+        "Cybersecurity Risks in Virtual Assets and Smart Contracts",
+        "虛擬資產與智能合約有哪些資安風險？",
+      ),
+      speakers: [
+        { name: "Martinet", organization: text("Quantstamp", "Quantstamp") },
+      ],
+    },
+    forum: {
+      format: text("Talk", "專題演講"),
+      title: text("Topic to be announced", "議題即將公布"),
+      speakers: [
+        { organization: text("O-Bank", "王道銀行"), status: "pending" },
+      ],
+    },
+  },
+  {
+    time: "14:00–14:05",
+    dateTime: "2026-09-14T14:00:00+08:00",
+    transition: text("Break", "休息時間"),
+  },
+  {
+    time: "14:05–14:35",
+    dateTime: "2026-09-14T14:05:00+08:00",
+    main: {
+      format: text("Talk", "專題演講"),
+      title: text(
+        "ETHSystem: An Introduction to Institutional-Grade Ethereum Infrastructure",
+        "認識 ETHSystem：機構級 Ethereum 基礎設施",
+      ),
+      speakers: [
+        { name: "Oskar", organization: text("ETHSystem", "ETHSystem") },
+      ],
+    },
+    forum: {
+      format: text("Talk", "專題演講"),
+      title: text("An RWA Risk-Control Framework", "RWA 的風險該怎麼管？"),
+      speakers: [
+        { name: "陳鴻祺", organization: text("Deloitte", "Deloitte") },
+      ],
+    },
+  },
+  {
+    time: "14:35–14:40",
+    dateTime: "2026-09-14T14:35:00+08:00",
+    transition: text("Break", "休息時間"),
+  },
+  {
+    time: "14:40–15:25",
+    dateTime: "2026-09-14T14:40:00+08:00",
+    main: {
+      format: text("Panel", "座談"),
+      title: text(
+        "Public, Private, or Hybrid Chains: How Institutions Should Choose",
+        "公鏈、私有鏈還是混合架構？機構該怎麼選？",
+      ),
+      speakers: [
+        { name: "Martinet", organization: text("Quantstamp", "Quantstamp") },
+        { name: "Ko-Wei", organization: text("IOTA", "IOTA") },
+        { name: "Benji", organization: text("LINE NEXT", "LINE NEXT") },
+        { name: "Teagan", organization: text("Canton", "Canton") },
+      ],
+    },
+    forum: {
+      format: text("Panel", "座談"),
+      title: text(
+        "Digital Asset Custody: Governance, Security, and Accountability",
+        "虛擬資產該怎麼保管？治理、資安與責任怎麼分？",
+      ),
+      speakers: [
+        { name: "Danny", organization: text("TAAS", "TAAS") },
+        { organization: text("BitGo", "BitGo"), status: "pending" },
+        { organization: text("KPMG", "KPMG"), status: "pending" },
+        { name: "Stamford", organization: text("Taishin", "Taishin") },
+      ],
+    },
+  },
+  {
+    time: "15:25–15:30",
+    dateTime: "2026-09-14T15:25:00+08:00",
+    transition: text("Break", "休息時間"),
+  },
+  {
+    time: "15:30–16:15",
+    dateTime: "2026-09-14T15:30:00+08:00",
+    main: {
+      format: text("Panel", "座談"),
+      title: text(
+        "Tokenization at Traditional Financial Institutions: From Pilots to Market Adoption",
+        "傳統金融如何推動代幣化？從試辦走向市場",
+      ),
+      speakers: [
+        { name: "Daniel", organization: text("BSOS", "BSOS") },
+        { name: "陳品", organization: text("BSOS", "BSOS") },
+        { status: "pending" },
+      ],
+    },
+    forum: {
+      format: text("Panel", "座談"),
+      title: text(
+        "Virtual Asset Regulatory Readiness: What's Still Missing?",
+        "虛擬資產法規準備好了嗎？市場還缺哪一塊？",
+      ),
+      speakers: [
+        { name: "Liying" },
+        { name: "Jason Lai" },
+        { name: "Ernie" },
+        { status: "pending" },
+      ],
+    },
+  },
+  {
+    time: text("From 16:15", "16:15 起"),
+    dateTime: "2026-09-14T16:15:00+08:00",
+    intermission: {
+      icon: "🤝",
+      title: text("Networking", "自由交流"),
+    },
+  },
+];
+
+const SpeakerList = ({
+  speakers,
+  locale,
+  copy,
+}: {
+  speakers?: Speaker[];
+  locale: Locale;
+  copy: (typeof UI_COPY)[Locale];
+}) => {
+  if (!speakers?.length) return null;
+
+  return (
+    <p className={styles.speakers}>
+      {speakers.map((speaker, index) => (
+        <span
+          className={speaker.status === "pending" ? styles.pendingSpeaker : ""}
+          key={`${speaker.name ?? "pending"}-${
+            speaker.organization
+              ? localize(speaker.organization, locale)
+              : index
+          }`}
+        >
+          {index > 0 && " · "}
+          {speaker.status === "pending" ? (
+            <>
+              {speaker.organization
+                ? `${localize(speaker.organization, locale)}${copy.labelSeparator}${copy.pendingSpeaker}`
+                : copy.moreSpeakersPending}
+            </>
+          ) : (
+            <>
+              {speaker.role && (
+                <span className={styles.speakerRole}>
+                  {localize(speaker.role, locale)}
+                  {copy.labelSeparator}
+                </span>
+              )}
+              {speaker.name}
+              {speaker.alias &&
+                `${copy.openParen}${speaker.alias}${copy.closeParen}`}
+              {(speaker.jobTitle || speaker.organization) && (
+                <span className={styles.organization}>
+                  {copy.openParen}
+                  {[
+                    speaker.jobTitle && localize(speaker.jobTitle, locale),
+                    speaker.organization && localize(speaker.organization, locale),
+                  ]
+                    .filter(Boolean)
+                    .join(copy.detailSeparator)}
+                  {copy.closeParen}
+                </span>
+              )}
+            </>
+          )}
+        </span>
+      ))}
+    </p>
+  );
+};
+
+const SessionCard = ({
+  session,
+  stage,
+  locale,
+  copy,
+}: {
+  session: Session;
+  stage: "main" | "forum" | "shared";
+  locale: Locale;
+  copy: (typeof UI_COPY)[Locale];
+}) => (
+  <article
+    className={`${styles.session} ${
+      stage === "forum" ? styles.forumSession : ""
+    } ${stage === "shared" ? styles.sharedSession : ""}`}
+  >
+    <div className={styles.sessionMeta}>
+      <span>{localize(session.format, locale)}</span>
+    </div>
+    <h3>{localize(session.title, locale)}</h3>
+    <SpeakerList speakers={session.speakers} locale={locale} copy={copy} />
+  </article>
+);
+
+const ScheduleRow = ({
+  row,
+  locale,
+  copy,
+}: {
+  row: AgendaRow;
+  locale: Locale;
+  copy: (typeof UI_COPY)[Locale];
+}) => {
+  const isTransition = Boolean(row.transition);
+
+  return (
+    <tr
+      className={`${styles.agendaRow} ${
+        isTransition ? styles.transitionRow : ""
+      }`}
+    >
+      <th className={styles.time} scope="row">
+        <time dateTime={row.dateTime}>
+          <strong>{localize(row.time, locale)}</strong>
+        </time>
+      </th>
+
+      {row.transition && (
+        <td className={styles.transition} colSpan={2}>
+          <span className={styles.transitionIcon} aria-hidden="true">
+            ⏳
+          </span>
+          {localize(row.transition, locale)}
+        </td>
+      )}
+
+      {row.intermission && (
+        <td className={styles.intermission} colSpan={2}>
+          <div className={styles.intermissionCopy}>
+            <span className={styles.intermissionIcon} aria-hidden="true">
+              {row.intermission.icon}
+            </span>
+            <div>
+              <h3>{localize(row.intermission.title, locale)}</h3>
+            </div>
+          </div>
+        </td>
+      )}
+
+      {row.shared && (
+        <td
+          className={`${styles.sessionCell} ${styles.wideCell}`}
+          colSpan={2}
+          data-stage-label={copy.sharedStage}
+        >
+          <SessionCard
+            session={row.shared}
+            stage="shared"
+            locale={locale}
+            copy={copy}
+          />
+        </td>
+      )}
+      {row.main && (
+        <td className={styles.sessionCell} data-stage-label={copy.mainStage}>
+          <SessionCard
+            session={row.main}
+            stage="main"
+            locale={locale}
+            copy={copy}
+          />
+        </td>
+      )}
+      {row.forum && (
+        <td className={styles.sessionCell} data-stage-label={copy.forumStage}>
+          <SessionCard
+            session={row.forum}
+            stage="forum"
+            locale={locale}
+            copy={copy}
+          />
+        </td>
+      )}
+    </tr>
+  );
 };
 
 const AgendaPage2026 = ({
@@ -382,116 +491,72 @@ const AgendaPage2026 = ({
   initialCfpPhase: CfpPhase;
 }) => {
   const { locale } = useLanguage();
-  const copy = COPY[locale];
-  const [activeDay, setActiveDay] = useState<DayId>("day1");
+  const copy = UI_COPY[locale];
 
   return (
-    <div className={`${homeStyles.page} ${styles.page}`} data-day={activeDay}>
+    <div
+      className={`${homeStyles.page} ${styles.page}`}
+      data-locale={locale}
+    >
+      <Head>
+        <title>{copy.metaTitle}</title>
+        <meta name="description" content={copy.metaDescription} />
+      </Head>
+
       <Header2026 activeHref="/agenda" initialCfpPhase={initialCfpPhase} />
 
-      <main className={styles.main} id="agenda">
+      <main
+        className={styles.main}
+        id="agenda"
+        lang={locale === "en" ? "en" : "zh-Hant"}
+      >
         <div className={styles.shell}>
-          <header className={styles.intro}>
-            <p className={styles.eyebrow}>{copy.eyebrow}</p>
-            <h1 className={styles.title}>
-              {copy.title}
-              <span>.</span>
-            </h1>
-            <p className={styles.lede}>{copy.lede}</p>
-          </header>
+          <section className={styles.hero} aria-labelledby="page-title">
+            <div>
+              <p className={styles.eyebrow}>{copy.eyebrow}</p>
+              <h1 id="page-title" className={styles.title}>
+                {copy.title}
+              </h1>
+              <time className={styles.eventDate} dateTime="2026-09-14">
+                {copy.eventDate}
+              </time>
+            </div>
+          </section>
 
-          <div className={styles.dayTabs} role="tablist" aria-label="Agenda days">
-            {copy.days.map((day) => (
-              <button
-                key={day.id}
-                className={styles.dayTab}
-                type="button"
-                role="tab"
-                aria-selected={activeDay === day.id}
-                onClick={() => setActiveDay(day.id)}
-              >
-                <span className={styles.dayTabDate}>{day.date}</span>
-                <span className={styles.dayTabName}>{day.name}</span>
-              </button>
-            ))}
-          </div>
-
-          {activeDay === "day1" ? (
-            <section className={styles.panel} aria-label={copy.day1.bandName}>
-              <div className={styles.bandCard}>
-                <span className={styles.bandTag}>{copy.day1.bandTag}</span>
-                <h2 className={styles.bandName}>{copy.day1.bandName}</h2>
-                <p className={styles.bandSub}>{copy.day1.bandSub}</p>
+          <section className={styles.agendaSection} aria-label={copy.sectionLabel}>
+            <div className={styles.sectionHeading}>
+              <div>
+                <p className={styles.sectionKicker}>{copy.scheduleLabel}</p>
               </div>
+            </div>
 
-              <p className={styles.sectionLabel}>{copy.day1.sectionLabel}</p>
-              <div className={styles.pillars}>
-                {copy.day1.pillars.map((pillar) => (
-                  <article className={styles.pillar} key={pillar.n}>
-                    <span className={styles.pillarNum} aria-hidden="true">
-                      {pillar.n}
-                    </span>
-                    <h3 className={styles.pillarTitle}>{pillar.title}</h3>
-                    <p className={styles.pillarDesc}>{pillar.desc}</p>
-                  </article>
+            <table className={styles.agendaTable}>
+              <caption className={styles.visuallyHidden}>{copy.caption}</caption>
+              <thead className={styles.agendaHead}>
+                <tr className={styles.agendaHeadRow}>
+                  <th className={styles.headCell} scope="col">
+                    {copy.timeHeader}
+                  </th>
+                  <th className={styles.headCell} scope="col">
+                    {copy.mainStage}
+                  </th>
+                  <th className={styles.headCell} scope="col">
+                    {copy.forumStage}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className={styles.agendaBody}>
+                {AGENDA_ROWS.map((row) => (
+                  <ScheduleRow
+                    row={row}
+                    locale={locale}
+                    copy={copy}
+                    key={row.dateTime}
+                  />
                 ))}
-              </div>
-
-              <p className={styles.note}>{copy.day1.note}</p>
-            </section>
-          ) : (
-            <section className={styles.panel} aria-label={copy.day2.bandName}>
-              <div className={`${styles.bandCard} ${styles.bandCardAlt}`}>
-                <span className={styles.bandTag}>{copy.day2.bandTag}</span>
-                <h2 className={styles.bandName}>{copy.day2.bandName}</h2>
-                <p className={styles.bandSub}>{copy.day2.bandSub}</p>
-              </div>
-
-              {copy.day2.sessions.map((session) => (
-                <div className={styles.session} key={session.heading}>
-                  <div className={styles.sessionHead}>
-                    <h2>{session.heading}</h2>
-                    <span className={styles.sessionRange}>{session.range}</span>
-                  </div>
-                  {session.slots.map((slot) => (
-                    <div
-                      className={`${styles.slot} ${
-                        slot.format === "panel" ? styles.slotPanel : ""
-                      }`}
-                      key={slot.time + slot.title}
-                    >
-                      <div className={styles.slotTime}>
-                        {slot.time}
-                        <span className={styles.slotDur}>{slot.dur}</span>
-                      </div>
-                      <div>
-                        <p className={styles.slotTitle}>{slot.title}</p>
-                        <p className={styles.slotDesc}>{slot.desc}</p>
-                        <div className={styles.slotFooter}>
-                          <span
-                            className={`${styles.fmt} ${
-                              slot.format === "panel" ? styles.fmtPanel : styles.fmtTalk
-                            }`}
-                          >
-                            {slot.format === "panel" ? copy.fmtPanel : copy.fmtTalk}
-                          </span>
-                          <span className={styles.tag}>{slot.tag}</span>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                  {session.range === MORNING_RANGE && (
-                    <div className={styles.break}>
-                      <div className={styles.slotTime}>12:00</div>
-                      <div className={styles.breakLabel}>{copy.day2.breakLabel}</div>
-                    </div>
-                  )}
-                </div>
-              ))}
-
-              <p className={styles.note}>{copy.day2.note}</p>
-            </section>
-          )}
+              </tbody>
+            </table>
+          </section>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary

- replace the placeholder agenda with the Institution Day schedule and confirmed session details
- add participant-facing English and Traditional Chinese copy, including confirmed organizations and pending-speaker states
- improve agenda readability with updated typography, colors, semantic table structure, sticky desktop stage headers, and a mobile-friendly stacked layout
- remove internal-process wording, duration labels, program-focus content, and redundant event metadata

## Validation

- `npm run lint`
- `tsc --noEmit`
- `git diff --check`