### PR TITLE
fix: center EDM content pasted into Gmail

### DIFF
--- a/public/edm/2026/institution-day/edm-dark.html
+++ b/public/edm/2026/institution-day/edm-dark.html
@@ -116,7 +116,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #0a1220;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);">
+          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #0a1220; border-bottom: 1px solid #2b3b52; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #9eacbe; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-dark.html" style="color: #d4b46a; text-decoration: underline;">於瀏覽器中查看</a>

--- a/public/edm/2026/institution-day/edm-dark.html
+++ b/public/edm/2026/institution-day/edm-dark.html
@@ -113,11 +113,8 @@
       &#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;
     </div>
 
-    <center style="width: 100%; background-color: #0a1220; text-align: center;">
-    <table role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin: 0 auto; background-color: #0a1220;">
-      <tr>
-        <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28); text-align: left;">
+    <center style="padding: 20px 12px 40px; background-color: #0a1220; text-align: center;">
+      <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28); text-align: left;">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #0a1220; border-bottom: 1px solid #2b3b52; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #9eacbe; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-dark.html" style="color: #d4b46a; text-decoration: underline;">於瀏覽器中查看</a>
@@ -344,10 +341,7 @@
                 </p>
               </td>
             </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
+      </table>
     </center>
   </body>
 </html>

--- a/public/edm/2026/institution-day/edm-dark.html
+++ b/public/edm/2026/institution-day/edm-dark.html
@@ -116,7 +116,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #0a1220;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="width: 640px; max-width: 640px; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);">
+          <table class="email-shell" role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #0a1220; border-bottom: 1px solid #2b3b52; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #9eacbe; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-dark.html" style="color: #d4b46a; text-decoration: underline;">於瀏覽器中查看</a>

--- a/public/edm/2026/institution-day/edm-dark.html
+++ b/public/edm/2026/institution-day/edm-dark.html
@@ -113,10 +113,11 @@
       &#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;
     </div>
 
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #0a1220;">
+    <center style="width: 100%; background-color: #0a1220; text-align: center;">
+    <table role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin: 0 auto; background-color: #0a1220;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);">
+          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #101a2a; border: 1px solid #2b3b52; box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28); text-align: left;">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #0a1220; border-bottom: 1px solid #2b3b52; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #9eacbe; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-dark.html" style="color: #d4b46a; text-decoration: underline;">於瀏覽器中查看</a>
@@ -347,5 +348,6 @@
         </td>
       </tr>
     </table>
+    </center>
   </body>
 </html>

--- a/public/edm/2026/institution-day/edm-green.html
+++ b/public/edm/2026/institution-day/edm-green.html
@@ -115,11 +115,8 @@
       &#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;
     </div>
 
-    <center style="width: 100%; background-color: #f2f7f4; text-align: center;">
-    <table role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin: 0 auto; background-color: #f2f7f4;">
-      <tr>
-        <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10); text-align: left;">
+    <center style="padding: 20px 12px 40px; background-color: #f2f7f4; text-align: center;">
+      <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10); text-align: left;">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f8fbf9; border-bottom: 1px solid #d5e6dc; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5d6d64; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-green.html" style="color: #007a35; text-decoration: underline;">於瀏覽器中查看</a>
@@ -346,10 +343,7 @@
                 </p>
               </td>
             </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
+      </table>
     </center>
   </body>
 </html>

--- a/public/edm/2026/institution-day/edm-green.html
+++ b/public/edm/2026/institution-day/edm-green.html
@@ -118,7 +118,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #f2f7f4;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="width: 640px; max-width: 640px; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10);">
+          <table class="email-shell" role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10);">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f8fbf9; border-bottom: 1px solid #d5e6dc; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5d6d64; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-green.html" style="color: #007a35; text-decoration: underline;">於瀏覽器中查看</a>

--- a/public/edm/2026/institution-day/edm-green.html
+++ b/public/edm/2026/institution-day/edm-green.html
@@ -118,7 +118,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #f2f7f4;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10);">
+          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10);">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f8fbf9; border-bottom: 1px solid #d5e6dc; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5d6d64; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-green.html" style="color: #007a35; text-decoration: underline;">於瀏覽器中查看</a>

--- a/public/edm/2026/institution-day/edm-green.html
+++ b/public/edm/2026/institution-day/edm-green.html
@@ -115,10 +115,11 @@
       &#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;
     </div>
 
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #f2f7f4;">
+    <center style="width: 100%; background-color: #f2f7f4; text-align: center;">
+    <table role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin: 0 auto; background-color: #f2f7f4;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10);">
+          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d5e6dc; box-shadow: 0 12px 34px rgba(0, 130, 61, 0.10); text-align: left;">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f8fbf9; border-bottom: 1px solid #d5e6dc; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5d6d64; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-green.html" style="color: #007a35; text-decoration: underline;">於瀏覽器中查看</a>
@@ -349,5 +350,6 @@
         </td>
       </tr>
     </table>
+    </center>
   </body>
 </html>

--- a/public/edm/2026/institution-day/edm-light.html
+++ b/public/edm/2026/institution-day/edm-light.html
@@ -114,11 +114,8 @@
       &#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;
     </div>
 
-    <center style="width: 100%; background-color: #eef2f6; text-align: center;">
-    <table role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin: 0 auto; background-color: #eef2f6;">
-      <tr>
-        <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10); text-align: left;">
+    <center style="padding: 20px 12px 40px; background-color: #eef2f6; text-align: center;">
+      <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10); text-align: left;">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f7f9fb; border-bottom: 1px solid #d7dee8; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5f7185; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-light.html" style="color: #a87818; text-decoration: underline;">於瀏覽器中查看</a>
@@ -345,10 +342,7 @@
                 </p>
               </td>
             </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
+      </table>
     </center>
   </body>
 </html>

--- a/public/edm/2026/institution-day/edm-light.html
+++ b/public/edm/2026/institution-day/edm-light.html
@@ -117,7 +117,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #eef2f6;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10);">
+          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10);">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f7f9fb; border-bottom: 1px solid #d7dee8; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5f7185; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-light.html" style="color: #a87818; text-decoration: underline;">於瀏覽器中查看</a>

--- a/public/edm/2026/institution-day/edm-light.html
+++ b/public/edm/2026/institution-day/edm-light.html
@@ -117,7 +117,7 @@
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #eef2f6;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="width: 640px; max-width: 640px; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10);">
+          <table class="email-shell" role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10);">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f7f9fb; border-bottom: 1px solid #d7dee8; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5f7185; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-light.html" style="color: #a87818; text-decoration: underline;">於瀏覽器中查看</a>

--- a/public/edm/2026/institution-day/edm-light.html
+++ b/public/edm/2026/institution-day/edm-light.html
@@ -114,10 +114,11 @@
       &#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;
     </div>
 
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: #eef2f6;">
+    <center style="width: 100%; background-color: #eef2f6; text-align: center;">
+    <table role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin: 0 auto; background-color: #eef2f6;">
       <tr>
         <td align="center" style="padding: 20px 12px 40px;">
-          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10);">
+          <table class="email-shell" role="presentation" align="center" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; max-width: 640px; margin: 0 auto; background-color: #ffffff; border: 1px solid #d7dee8; box-shadow: 0 12px 34px rgba(23, 50, 77, 0.10); text-align: left;">
             <tr>
               <td class="mobile-pad" style="padding: 14px 36px; background-color: #f7f9fb; border-bottom: 1px solid #d7dee8; font-family: Arial, Helvetica, sans-serif; font-size: 11px; line-height: 16px; color: #5f7185; text-align: center;">
                 若郵件顯示不完整，請<a href="https://ethtaipei.org/edm/2026/institution-day/edm-light.html" style="color: #a87818; text-decoration: underline;">於瀏覽器中查看</a>
@@ -348,5 +349,6 @@
         </td>
       </tr>
     </table>
+    </center>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- make the dark, light, and green eDM shells fluid up to a 640px maximum width
- use email-safe centering attributes and automatic horizontal margins
- remove the full-width wrapper table that can preserve the source browser width when copied into Gmail, causing a large blank area on the left
- keep all content, links, and theme-specific colors unchanged

## Validation

- git diff --check
- HTML source validation completed with no structural errors; existing email-client compatibility warnings remain
- confirmed the PR only changes the three eDM HTML variants

## Manual check

After deployment, copy the rendered local or hosted eDM into a new blank Gmail draft and send a test message to confirm Gmail preserves centering.