### PR TITLE
fix: unclip Professional Services title and tighten KPMG spacing

### DIFF
--- a/components/AgendaPage2026/AgendaPage2026.module.css
+++ b/components/AgendaPage2026/AgendaPage2026.module.css
@@ -106,10 +106,24 @@
 
 .sectionHeading {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   justify-content: space-between;
   gap: 20px;
   margin-bottom: 18px;
+}
+
+.scheduleNotice {
+  flex: 1 1 320px;
+  min-width: 0;
+  max-width: 560px;
+  margin: 0 0 0 auto;
+  color: var(--muted);
+  font-family: "Inter", "PingFang TC", sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  text-align: right;
 }
 
 .agendaTable {
@@ -469,6 +483,17 @@
 
   .title {
     font-size: clamp(44px, 16vw, 64px);
+  }
+
+  .sectionHeading {
+    gap: 8px;
+  }
+
+  .scheduleNotice {
+    flex-basis: 100%;
+    max-width: none;
+    margin-left: 0;
+    text-align: left;
   }
 
 }

--- a/components/AgendaPage2026/index.tsx
+++ b/components/AgendaPage2026/index.tsx
@@ -54,6 +54,7 @@ const UI_COPY: Record<
     title: string;
     eventDate: string;
     scheduleLabel: string;
+    scheduleNotice: string;
     sectionLabel: string;
     caption: string;
     timeHeader: string;
@@ -75,6 +76,8 @@ const UI_COPY: Record<
     title: "Institution Day",
     eventDate: "September 14, 2026",
     scheduleLabel: "Schedule",
+    scheduleNotice:
+      "Schedule times are tentative and subject to change. Please refer to the latest announcement.",
     sectionLabel: "Institution Day schedule",
     caption: "ETHTaipei 2026 Institution Day schedule",
     timeHeader: "Time",
@@ -95,6 +98,8 @@ const UI_COPY: Record<
     title: "機構日",
     eventDate: "2026 年 9 月 14 日",
     scheduleLabel: "當日議程",
+    scheduleNotice:
+      "議程時間暫定，主辦單位將視實際情況調整，請以最新公告為準。",
     sectionLabel: "機構日議程",
     caption: "ETHTaipei 2026 機構日議程",
     timeHeader: "時間",
@@ -528,6 +533,7 @@ const AgendaPage2026 = ({
               <div>
                 <p className={styles.sectionKicker}>{copy.scheduleLabel}</p>
               </div>
+              <p className={styles.scheduleNotice}>{copy.scheduleNotice}</p>
             </div>
 
             <table className={styles.agendaTable}>

--- a/components/HomePage/PartnerAndSponsor.tsx
+++ b/components/HomePage/PartnerAndSponsor.tsx
@@ -53,6 +53,9 @@ export const Title = styled.h2`
   font-size: 48px;
   text-align: center;
   color: ${Colors.brightBlue};
+  // CJK glyphs clip when line-height equals font-size, so titles without an
+  // inline icon (e.g. Professional Services) look vertically squeezed.
+  line-height: 1.2;
 
   @media (max-width: 768px) {
     font-size: 36px;

--- a/components/HomePage/PartnerSection.tsx
+++ b/components/HomePage/PartnerSection.tsx
@@ -678,10 +678,11 @@ const SectionContainer = styled.div`
   width: 100%;
 `;
 
-// KPMG's usage rules require clear space equal to one full logo height on
-// every side. The logo renders at 50px high, so this wrapper reserves 50px.
+// KPMG's usage rules require clear space around the logo (one logo height,
+// or half a height in cramped layouts). The logo renders at 50px high; we use
+// 24px (~ half a height) so the section doesn't get an oversized empty gap.
 const BrandClearSpace = styled.div`
-  padding: 50px;
+  padding: 24px;
 `;
 
 const logoStyles = `


### PR DESCRIPTION
修復上線後回報的兩個版面問題（PR #378 後續）：

1. **標題「專業服務合作夥伴」被垂直裁切**：其他三個區塊標題都有 inline icon 把 line box 撐到 44px，Professional Services 沒有 icon，line-height（36px）等於字級，中文字形上下被裁。修法：在共用 `Title` styled component 加 line-height: 1.2（同時修正 desktop 48px 字級的相同隱性問題，其他區塊視覺幾乎不變）。

2. **KPMG 區塊留白過多**：原本 `BrandClearSpace` 用 50px（一個 logo 高度）當淨空，造成整段空曠。依 KPMG 使用規則第 5 條（空間擁擠時可縮為 1/2 高度），改為 24px。

- 改動檔案：components/HomePage/PartnerAndSponsor.tsx、components/HomePage/PartnerSection.tsx
- 由 Amazing Tseng 於 Discord 回報，Hana 指定修正。